### PR TITLE
Updates file paths and pipeline configuration so final data and metadata outputs are written to MEDS v0.3 compatible file paths.

### DIFF
--- a/pipeline_configuration.md
+++ b/pipeline_configuration.md
@@ -31,21 +31,21 @@ Suppose you have a pipeline with an input directory of `$INPUT_DIR` and a cohort
 Each of these stages will read and write their output datasets in the following manner.
 
 1. `stage_1`:
-   \* As there is no preceeding data stage, this stage will read the data in from `$INPUT_DIR/data`
-   (the `data` suffix is the default data directory for MEDS datasets).
-   \* This stage will, in its mapping stage, write the partial extracted metadata files to the
-   `$COHORT_DIR/stage_1/$SHARD_NAME.parquet` directory.
-   \* This stage will read in the prior joint metadata file from the `$INPUT_DIR/metadata/codes.parquet`
-   directory to join with the new metadata.
-   \* This stage will join all its metadata shards, join any prior columns from the old metadata, and
-   write the final, joined metadata file to the `$COHORT_DIR/stage_1/codes.parquet` directory.
+   * As there is no preceeding data stage, this stage will read the data in from `$INPUT_DIR/data`
+     (the `data` suffix is the default data directory for MEDS datasets).
+   * This stage will, in its mapping stage, write the partial extracted metadata files to the
+     `$COHORT_DIR/stage_1/$SHARD_NAME.parquet` directory.
+   * This stage will read in the prior joint metadata file from the `$INPUT_DIR/metadata/codes.parquet`
+     directory to join with the new metadata.
+   * This stage will join all its metadata shards, join any prior columns from the old metadata, and
+     write the final, joined metadata file to the `$COHORT_DIR/stage_1/codes.parquet` directory.
 2. `stage_2`:
-   \* This stage will read in the metadata from the `$COHORT_DIR/stage_1/codes.parquet` directory.
-   \* This stage will write the filtered metadata to the `$COHORT_DIR/stage_2/codes.parquet` directory.
+   * This stage will read in the metadata from the `$COHORT_DIR/stage_1/codes.parquet` directory.
+   * This stage will write the filtered metadata to the `$COHORT_DIR/stage_2/codes.parquet` directory.
 3. `stage_3`:
-   \* This stage will read in the data from the `$INPUT_DIR/data` directory as there has still been no
-   prior data processing stage. Individual shards will be read from the
-   `$INPUT_DIR/data/$SHARD_NAME.parquet` files.
-   \* This stage will read in the metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory.
-   \* This stage will write the filtered shards to the `$COHORT_DIR/stage_3/$SHARD_NAME.parquet` files.
+   * This stage will read in the data from the `$INPUT_DIR/data` directory as there has still been no
+     prior data processing stage. Individual shards will be read from the
+     `$INPUT_DIR/data/$SHARD_NAME.parquet` files.
+   * This stage will read in the metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory.
+   * This stage will write the filtered shards to the `$COHORT_DIR/stage_3/$SHARD_NAME.parquet` files.
 4. `stage_4`: ... TODO

--- a/pipeline_configuration.md
+++ b/pipeline_configuration.md
@@ -1,0 +1,51 @@
+# Pipeline Configuration in MEDS-Transform
+
+MEDS Transform's key design philosophy is that you should be able to design the necessary data pre-processing
+and transformation pipeline you need simply by composing a series of simple, reusable, efficient, and
+configurable local transformations into a larger pipeline. This can allow researchers to balance having highly
+flexible, customizable pipelines with ensuring that all operations in the pipeline are simple, shareable,
+efficient, and easy to validate.
+
+## Stages
+
+### File System Management
+
+Suppose you have a pipeline with an input directory of `$INPUT_DIR` and a cohort (output) directory of
+`$COHORT_DIR`. Let us further suppose we impose a series of the following stages:
+
+1. `stage_1`: A metadata map-reduce stage (e.g., counting the occurence rates of the codes in the
+   data).
+2. `stage_2`: A metadata-only processing stage (e.g., filtering the code dataframe to only codes
+   that occur more than 10 times).
+3. `stage_3`: A data processing stage (e.g., filtering the data to only rows with a code that is in the
+   current running metadata file, which, due to `stage_2`, are those codes that occur more than 10 times).
+4. `stage_4`: A metadata map-reduce stage (e.g., computing the means and variances for the numerical values
+   in the data).
+5. `stage_5`: A data processing stage (e.g., occluding all measurement values that occur more than 3
+   standard deviations from the mean).
+6. `stage_6`: A metadata map-reduce stage (e.g., computing the means and variances for the numerical values
+   in the data).
+7. `stage_7`: A data processing stage (e.g., normalizing the data to have a mean of 0 and a standard
+   deviation of 1).
+
+Each of these stages will read and write their output datasets in the following manner.
+
+1. `stage_1`:
+   \* As there is no preceeding data stage, this stage will read the data in from `$INPUT_DIR/data`
+   (the `data` suffix is the default data directory for MEDS datasets).
+   \* This stage will, in its mapping stage, write the partial extracted metadata files to the
+   `$COHORT_DIR/stage_1/$SHARD_NAME.parquet` directory.
+   \* This stage will read in the prior joint metadata file from the `$INPUT_DIR/metadata/codes.parquet`
+   directory to join with the new metadata.
+   \* This stage will join all its metadata shards, join any prior columns from the old metadata, and
+   write the final, joined metadata file to the `$COHORT_DIR/stage_1/codes.parquet` directory.
+2. `stage_2`:
+   \* This stage will read in the metadata from the `$COHORT_DIR/stage_1/codes.parquet` directory.
+   \* This stage will write the filtered metadata to the `$COHORT_DIR/stage_2/codes.parquet` directory.
+3. `stage_3`:
+   \* This stage will read in the data from the `$INPUT_DIR/data` directory as there has still been no
+   prior data processing stage. Individual shards will be read from the
+   `$INPUT_DIR/data/$SHARD_NAME.parquet` files.
+   \* This stage will read in the metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory.
+   \* This stage will write the filtered shards to the `$COHORT_DIR/stage_3/$SHARD_NAME.parquet` files.
+4. `stage_4`: ... TODO

--- a/pipeline_configuration.md
+++ b/pipeline_configuration.md
@@ -13,7 +13,7 @@ efficient, and easy to validate.
 Suppose you have a pipeline with an input directory of `$INPUT_DIR` and a cohort (output) directory of
 `$COHORT_DIR`. Let us further suppose we impose a series of the following stages:
 
-1. `stage_1`: A metadata map-reduce stage (e.g., counting the occurence rates of the codes in the
+1. `stage_1`: A metadata map-reduce stage (e.g., counting the occurrence rates of the codes in the
    data).
 2. `stage_2`: A metadata-only processing stage (e.g., filtering the code dataframe to only codes
    that occur more than 10 times).
@@ -31,21 +31,52 @@ Suppose you have a pipeline with an input directory of `$INPUT_DIR` and a cohort
 Each of these stages will read and write their output datasets in the following manner.
 
 1. `stage_1`:
-   * As there is no preceeding data stage, this stage will read the data in from `$INPUT_DIR/data`
+   - As there is no preceding data stage, this stage will read the data in from `$INPUT_DIR/data`
      (the `data` suffix is the default data directory for MEDS datasets).
-   * This stage will, in its mapping stage, write the partial extracted metadata files to the
+   - This stage will, in its mapping stage, write the partial extracted metadata files to the
      `$COHORT_DIR/stage_1/$SHARD_NAME.parquet` directory.
-   * This stage will read in the prior joint metadata file from the `$INPUT_DIR/metadata/codes.parquet`
+   - This stage will read in the prior joint metadata file from the `$INPUT_DIR/metadata/codes.parquet`
      directory to join with the new metadata.
-   * This stage will join all its metadata shards, join any prior columns from the old metadata, and
+   - This stage will join all its metadata shards, join any prior columns from the old metadata, and
      write the final, joined metadata file to the `$COHORT_DIR/stage_1/codes.parquet` directory.
 2. `stage_2`:
-   * This stage will read in the metadata from the `$COHORT_DIR/stage_1/codes.parquet` directory.
-   * This stage will write the filtered metadata to the `$COHORT_DIR/stage_2/codes.parquet` directory.
+   - This stage will read in the metadata from the `$COHORT_DIR/stage_1/codes.parquet` directory.
+   - This stage will write the filtered metadata to the `$COHORT_DIR/stage_2/codes.parquet` directory.
 3. `stage_3`:
-   * This stage will read in the data from the `$INPUT_DIR/data` directory as there has still been no
+   - This stage will read in the data from the `$INPUT_DIR/data` directory as there has still been no
      prior data processing stage. Individual shards will be read from the
      `$INPUT_DIR/data/$SHARD_NAME.parquet` files.
-   * This stage will read in the metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory.
-   * This stage will write the filtered shards to the `$COHORT_DIR/stage_3/$SHARD_NAME.parquet` files.
-4. `stage_4`: ... TODO
+   - This stage will read in the metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory.
+   - This stage will write the filtered shards to the `$COHORT_DIR/stage_3/$SHARD_NAME.parquet` files.
+4. `stage_4`:
+   - This stage will read in the data from the `$COHORT_DIR/stage_3` directory as that is the prior data
+     processing stage.
+   - This stage will write the partial extracted metadata files to the
+     `$COHORT_DIR/stage_4/$SHARD_NAME.parquet` file.
+   - This stage will read in the prior metadata from the `$COHORT_DIR/stage_2/codes.parquet` directory and
+     join it with the new metadata.
+   - This stage will join all its metadata shards, join any prior columns from the old metadata, and
+     write the final, joined metadata file to the `$COHORT_DIR/stage_4/codes.parquet` file.
+5. `stage_5`:
+   - This stage will read in the data from the `$COHORT_DIR/stage_3` directory.
+   - This stage will read in the metadata from the `$COHORT_DIR/stage_4/codes.parquet` file.
+   - This stage will write the filtered shards to the `$COHORT_DIR/stage_5/$SHARD_NAME.parquet` files.
+6. `stage_6`:
+   - This stage will read in the data from the `$COHORT_DIR/stage_5` directory.
+   - This stage will write the partial extracted metadata files to the
+     `$COHORT_DIR/stage_6/$SHARD_NAME.parquet` file.
+   - This stage will read in the prior metadata from the `$COHORT_DIR/stage_4/codes.parquet` file and
+     join it with the new metadata.
+   - This stage will join all its metadata shards, join any prior columns from the old metadata, and
+     write the final, joined metadata file to both the `$COHORT_DIR/stage_6/codes.parquet` file and to the
+     `$COHORT_DIR/metadata/codes.parquet` file _given that this is the last metadata stage in the pipeline._
+     Note that this reduced file is the only metadata file written in the global cohort metadata directory;
+     the partial map files are only written to the stage directories.
+7. `stage_7`:
+   - This stage will read in the data from the `$COHORT_DIR/stage_5` directory.
+   - This stage will read in the metadata from the `$COHORT_DIR/stage_6/codes.parquet` file.
+   - This stage will write the normalized shards to the `$COHORT_DIR/data/$SHARD_NAME.parquet` files, using
+     the _global cohort data directory given that this is the last data processing stage in the pipeline._
+     Note that, unlike for metadata, where only the reduce output is written to the global cohort metadata
+     file, all data shards are written to the global cohort data directory for final data processing stages
+     (which do not have reduce stages).

--- a/preprocessing_operation_prototypes.md
+++ b/preprocessing_operation_prototypes.md
@@ -41,7 +41,7 @@ preparation for mapping that transformation out across the patient data by code.
 
 ##### Operation Steps
 
-1. Add new information or transform existing columns in an existing `code_metadata.parquet` file. Note that
+1. Add new information or transform existing columns in an existing `metadata/codes.parquet` file. Note that
    `code` or `code_modifier` columns should _not_ be modified in this step as that will break the linkage
    with the patient data.
 
@@ -72,7 +72,7 @@ simplicity).
 1. Per-shard, filter the pateint data to satisfy desired set of patient or other data critieria.
 2. Per-shard, group by code and collect some aggregate statistics. Optionally also compute statistics across
    all codes.
-3. Reduce the per-shard aggregate files into a unified `code_metadata.parquet` file.
+3. Reduce the per-shard aggregate files into a unified `metadata/codes.parquet` file.
 4. Optionally merge with static per-code metadata from prior steps.
 
 ##### Parameters
@@ -94,7 +94,7 @@ Patient Filters: **None**
 
 Functions:
 
-1. Various aggregation functions; see `src/MEDS_transforms/code_metadata.py` for a list of supported
+1. Various aggregation functions; see `src/MEDS_transforms/aggregate_code_metadata.py` for a list of supported
    functions.
 
 ##### Planned Future Operations
@@ -145,11 +145,11 @@ None at this time. To request a new operation, please open a GitHub issue.
 #### Filtering Measurements
 
 This operation assumes that any requisite aggregate, per-code information is pre-computed and can be joined in
-via a `code_metadata.parquet` file.
+via a `metadata/codes.parquet` file.
 
 ##### Operation Steps
 
-1. Per-shard, join the data, if necessary, to the provided, global `code_metadata.parquet` file.
+1. Per-shard, join the data, if necessary, to the provided, global `metadata/codes.parquet` file.
 2. Apply row-based criteria to each measurement to determine if it should be retained or removed.
 3. Return the filtered dataset, in the same format as the original, but with only the measurements to be
    retained.
@@ -157,7 +157,7 @@ via a `code_metadata.parquet` file.
 ##### Parameters
 
 1. What criteria should be used to filter measurements.
-2. What, if any, columns in the `code_metadata.parquet` file should be joined in to the data.
+2. What, if any, columns in the `metadata/codes.parquet` file should be joined in to the data.
 
 ##### Status
 
@@ -168,7 +168,7 @@ but supports such extension relatively natively.
 ##### Currently supported operations
 
 Currently, measurements can be filtered on the basis of `min_patients_per_code` and `min_occurrences_per_code`
-thresholds, which are read from the `code_metadata.parquet` file via the `code/n_patients` and
+thresholds, which are read from the `metadata/codes.parquet` file via the `code/n_patients` and
 `code/n_occurrences` columns, respectively.
 
 ##### Planned Future Operations
@@ -190,7 +190,7 @@ order), see the "Transforming Measurements within Events" section.
 #### Occluding Features within Measurements
 
 This operation assumes that any requisite aggregate, per-code information is pre-computed and can be joined in
-via a `code_metadata.parquet` file.
+via a `metadata/codes.parquet` file.
 
 **TODO** This is not really a prototype, but is really a single function, or a subset of a prototype. IT has
 functionally the same API as numerical value normalization, with the modification that the indicator columns
@@ -198,7 +198,7 @@ are added and this function is not reversible.
 
 ##### Operation Steps
 
-1. Per-shard, join the data, if necessary, to the provided, global `code_metadata.parquet` file.
+1. Per-shard, join the data, if necessary, to the provided, global `metadata/codes.parquet` file.
 2. Apply row-based criteria to each measurement to determine if individual features should be occluded or
    retained in full granularity.
 3. Set occluded data to the occlusion target (typically `"UNK"`, `None`, or `np.NaN`) and add an indicator
@@ -209,7 +209,7 @@ are added and this function is not reversible.
 1. What criteria should be used to occlude features.
    - Relatedly, what occlusion value should be used for occluded features.
    - Relatedly, what the name of the occlusion column should be (can be set by default for features).
-2. What, if any, columns in the `code_metadata.parquet` file should be joined in to the data.
+2. What, if any, columns in the `metadata/codes.parquet` file should be joined in to the data.
 
 ##### Status
 

--- a/src/MEDS_transforms/configs/extract.yaml
+++ b/src/MEDS_transforms/configs/extract.yaml
@@ -38,6 +38,8 @@ stages:
   - extract_code_metadata
 
 stage_configs:
+  shard_events:
+    data_input_dir: "${input_dir}"
   aggregate_code_metadata:
     description: |-
       This stage collects some descriptive metadata about the codes in the cohort.

--- a/src/MEDS_transforms/configs/extract.yaml
+++ b/src/MEDS_transforms/configs/extract.yaml
@@ -56,7 +56,6 @@ stage_configs:
       - "values/sum"
       - "values/sum_sqd"
     do_summarize_over_all_codes: true # This indicates we should include overall, code-independent counts
-    is_metadata: True
-    mapper_output_dir: "${cohort_dir}/code_metadata"
-    output_dir: "${cohort_dir}"
     process_shard_prefix: "train/" # we only want to summarize over the training set
+  extract_code_metadata:
+    is_metadata: true

--- a/src/MEDS_transforms/configs/stage_configs/filter_patients.yaml
+++ b/src/MEDS_transforms/configs/stage_configs/filter_patients.yaml
@@ -1,4 +1,3 @@
 filter_patients:
   min_events_per_patient: null
   min_measurements_per_patient: null
-  data_input_dir: ${input_dir}/final_cohort

--- a/src/MEDS_transforms/configs/stage_configs/merge_to_MEDS_cohort.yaml
+++ b/src/MEDS_transforms/configs/stage_configs/merge_to_MEDS_cohort.yaml
@@ -1,4 +1,3 @@
 merge_to_MEDS_cohort:
-  output_dir: ${cohort_dir}/final_cohort
   unique_by: "*"
   additional_sort_by: null

--- a/src/MEDS_transforms/extract/README.md
+++ b/src/MEDS_transforms/extract/README.md
@@ -109,7 +109,7 @@ configuration options for this block in the `tests/test_extract.py` file and in 
 This block tells the system to read the file `$INPUT_DIR/metadata_table_file_stem.$SUFFIX`, to collect the
 columns necessary to construct the `code` field for `event_name`, potentially renaming columns according to
 `_code_name_map` first, alongside any input columns specified in the block, then to construct a
-`code_metadata.parquet` dataframe which links the metadata columns to the realized codes for the dataset. See
+`metadata/codes.parquet` dataframe which links the metadata columns to the realized codes for the dataset. See
 the [Partial MIMIC-IV Example](#partial-mimic-iv-example) below for an example of this in action.
 
 #### Examples

--- a/src/MEDS_transforms/extract/extract_code_metadata.py
+++ b/src/MEDS_transforms/extract/extract_code_metadata.py
@@ -388,13 +388,16 @@ def main(cfg: DictConfig):
     else:
         reduced = reduced.collect()
 
-    reducer_fp = Path(cfg.cohort_dir) / "code_metadata.parquet"
+    metadata_input_dir = Path(cfg.stage_cfg.metadata_input_dir)
+    old_metadata_fp = metadata_input_dir / "codes.parquet"
 
-    if reducer_fp.exists():
-        logger.info(f"Joining to existing code metadata at {str(reducer_fp.resolve())}")
-        existing = pl.read_parquet(reducer_fp, use_pyarrow=True)
+    if old_metadata_fp.exists():
+        logger.info(f"Joining to existing code metadata at {str(old_metadata_fp.resolve())}")
+        existing = pl.read_parquet(old_metadata_fp, use_pyarrow=True)
         reduced = existing.join(reduced, on=join_cols, how="full", coalesce=True)
 
+    reducer_fp = Path(cfg.stage_cfg.reducer_output_dir) / "codes.parquet"
+    reducer_fp.parent.mkdir(parents=True, exist_ok=True)
     reduced.write_parquet(reducer_fp, use_pyarrow=True)
     logger.info(f"Finished reduction in {datetime.now() - start}")
 

--- a/src/MEDS_transforms/filters/filter_measurements.py
+++ b/src/MEDS_transforms/filters/filter_measurements.py
@@ -149,7 +149,7 @@ def main(cfg: DictConfig):
     """TODO."""
 
     code_metadata = pl.read_parquet(
-        Path(cfg.stage_cfg.metadata_input_dir) / "code_metadata.parquet", use_pyarrow=True
+        Path(cfg.stage_cfg.metadata_input_dir) / "codes.parquet", use_pyarrow=True
     )
     compute_fn = filter_measurements_fntr(cfg.stage_cfg, code_metadata)
 

--- a/src/MEDS_transforms/fit_vocabulary_indices.py
+++ b/src/MEDS_transforms/fit_vocabulary_indices.py
@@ -207,9 +207,9 @@ def main(cfg: DictConfig):
     )
 
     metadata_input_dir = Path(cfg.stage_cfg.metadata_input_dir)
-    output_dir = Path(cfg.stage_cfg.output_dir)
+    output_dir = Path(cfg.stage_cfg.reducer_output_dir)
 
-    code_metadata = pl.read_parquet(metadata_input_dir / "code_metadata.parquet", use_pyarrow=True)
+    code_metadata = pl.read_parquet(metadata_input_dir / "codes.parquet", use_pyarrow=True)
 
     ordering_method = cfg.stage_cfg.get("ordering_method", VOCABULARY_ORDERING.LEXICOGRAPHIC)
 
@@ -228,7 +228,8 @@ def main(cfg: DictConfig):
 
     code_metadata = ordering_fn(code_metadata, code_modifiers)
 
-    output_fp = output_dir / "code_metadata.parquet"
+    output_fp = output_dir / "codes.parquet"
+    output_fp.parent.mkdir(parents=True, exist_ok=True)
     logger.info(f"Indices assigned. Writing to {output_fp}")
 
     code_metadata.write_parquet(output_fp, use_pyarrow=True)

--- a/src/MEDS_transforms/transforms/add_time_derived_measurements.py
+++ b/src/MEDS_transforms/transforms/add_time_derived_measurements.py
@@ -369,7 +369,13 @@ def time_of_day_fntr(cfg: DictConfig) -> Callable[[pl.DataFrame], pl.DataFrame]:
 
 
 def add_time_derived_measurements_fntr(stage_cfg: DictConfig) -> Callable[[pl.LazyFrame], pl.LazyFrame]:
-    INFERRED_STAGE_KEYS = {"is_metadata", "data_input_dir", "metadata_input_dir", "output_dir"}
+    INFERRED_STAGE_KEYS = {
+        "is_metadata",
+        "data_input_dir",
+        "metadata_input_dir",
+        "output_dir",
+        "reducer_output_dir",
+    }
 
     compute_fns = []
     # We use the raw stages object as the induced `stage_cfg` has extra properties like the input and output

--- a/src/MEDS_transforms/transforms/normalization.py
+++ b/src/MEDS_transforms/transforms/normalization.py
@@ -222,7 +222,7 @@ def main(cfg: DictConfig):
     """TODO."""
 
     code_metadata = pl.read_parquet(
-        Path(cfg.stage_cfg.metadata_input_dir) / "code_metadata.parquet", use_pyarrow=True
+        Path(cfg.stage_cfg.metadata_input_dir) / "codes.parquet", use_pyarrow=True
     ).lazy()
     code_modifiers = cfg.get("code_modifier_columns", None)
     compute_fn = partial(normalize, code_metadata=code_metadata, code_modifiers=code_modifiers)

--- a/src/MEDS_transforms/transforms/occlude_outliers.py
+++ b/src/MEDS_transforms/transforms/occlude_outliers.py
@@ -111,7 +111,7 @@ def main(cfg: DictConfig):
     """TODO."""
 
     code_metadata = pl.read_parquet(
-        Path(cfg.stage_cfg.metadata_input_dir) / "code_metadata.parquet", use_pyarrow=True
+        Path(cfg.stage_cfg.metadata_input_dir) / "codes.parquet", use_pyarrow=True
     )
     compute_fn = occlude_outliers_fntr(cfg.stage_cfg, code_metadata)
 

--- a/src/MEDS_transforms/utils.py
+++ b/src/MEDS_transforms/utils.py
@@ -153,10 +153,10 @@ def populate_stage(
         ... })
         >>> args = [root_config[k] for k in ["input_dir", "cohort_dir", "stages", "stage_configs"]]
         >>> populate_stage("stage1", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'is_metadata': False, 'data_input_dir': '/a/b', 'metadata_input_dir': '/a/b',
+        {'is_metadata': False, 'data_input_dir': '/a/b/data', 'metadata_input_dir': '/a/b/metadata',
          'output_dir': '/c/d/stage1'}
         >>> populate_stage("stage2", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'is_metadata': True, 'data_input_dir': '/c/d/stage1', 'metadata_input_dir': '/a/b',
+        {'is_metadata': True, 'data_input_dir': '/c/d/stage1', 'metadata_input_dir': '/a/b/metadata',
          'output_dir': '/c/d/stage2'}
         >>> populate_stage("stage3", *args) # doctest: +NORMALIZE_WHITESPACE
         {'is_metadata': False, 'data_input_dir': '/c/d/stage1',
@@ -212,13 +212,22 @@ def populate_stage(
         else:
             prior_data_stage = s_resolved
 
+    is_first_data_stage = prior_data_stage is None
+    is_first_metadata_stage = prior_metadata_stage is None
+
+    input_dir = Path(input_dir)
+    cohort_dir = Path(cohort_dir)
+
+    pipeline_input_data_dir = str(input_dir / "data")
+    pipeline_input_metadata_dir = str(input_dir / "metadata")
+
     inferred_keys = {
         "is_metadata": "aggregations" in stage,
-        "data_input_dir": input_dir if prior_data_stage is None else prior_data_stage["output_dir"],
+        "data_input_dir": pipeline_input_data_dir if is_first_data_stage else prior_data_stage["output_dir"],
         "metadata_input_dir": (
-            input_dir if prior_metadata_stage is None else prior_metadata_stage["output_dir"]
+            pipeline_input_metadata_dir if is_first_metadata_stage else prior_metadata_stage["output_dir"]
         ),
-        "output_dir": os.path.join(cohort_dir, stage_name),
+        "output_dir": cohort_dir / stage_name,
     }
 
     if "is_metadata" in stage and not isinstance(stage["is_metadata"], (bool, type(None))):

--- a/src/MEDS_transforms/utils.py
+++ b/src/MEDS_transforms/utils.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import hydra
 import polars as pl
@@ -102,6 +103,48 @@ def current_script_name() -> str:
     return Path(sys.argv[0]).stem
 
 
+def is_metadata_stage(stage: dict[str, Any] | DictConfig) -> bool:
+    """Determines if a stage is a metadata stage either by explicit argument or via the "aggregations" key.
+
+    Args:
+        stage: The stage configuration dictionary.
+
+    Returns:
+        bool: True if the stage is a metadata stage, False otherwise.
+
+    Raises:
+        TypeError: If the "is_metadata" key is present but not a boolean or `None`.
+
+    Examples:
+        >>> is_metadata_stage({"aggregations": ["foo"]})
+        True
+        >>> is_metadata_stage({"is_metadata": True})
+        True
+        >>> is_metadata_stage({"is_metadata": False})
+        False
+        >>> is_metadata_stage({"is_metadata": None})
+        False
+        >>> is_metadata_stage({"output_dir": "/a/b/metadata"})
+        False
+        >>> is_metadata_stage({})
+        False
+        >>> is_metadata_stage(DictConfig({"aggregations": ["foo"]}))
+        True
+        >>> is_metadata_stage(DictConfig({"is_metadata": 32}))
+        Traceback (most recent call last):
+            ...
+        TypeError: If specified manually, is_metadata must be a boolean. Got 32
+    """
+    if "is_metadata" in stage:
+        if not isinstance(stage["is_metadata"], (bool, type(None))):
+            raise TypeError(
+                f"If specified manually, is_metadata must be a boolean. Got {stage['is_metadata']}"
+            )
+        return bool(stage["is_metadata"])
+    else:
+        return "aggregations" in stage
+
+
 def populate_stage(
     stage_name: str,
     input_dir: str,
@@ -146,30 +189,31 @@ def populate_stage(
         ...     "stages": ["stage1", "stage2", "stage3", "stage4", "stage5", "stage6"],
         ...     "stage_configs": {
         ...         "stage2": {"is_metadata": True},
-        ...         "stage3": {"is_metadata": None},
-        ...         "stage4": {"data_input_dir": "/e/f", "output_dir": "/g/h"},
+        ...         "stage3": {"is_metadata": None, "output_dir": "/g/h"},
+        ...         "stage4": {"data_input_dir": "/e/f"},
         ...         "stage5": {"aggregations": ["foo"]},
         ...     },
         ... })
         >>> args = [root_config[k] for k in ["input_dir", "cohort_dir", "stages", "stage_configs"]]
         >>> populate_stage("stage1", *args) # doctest: +NORMALIZE_WHITESPACE
         {'is_metadata': False, 'data_input_dir': '/a/b/data', 'metadata_input_dir': '/a/b/metadata',
-         'output_dir': '/c/d/stage1'}
+         'output_dir': '/c/d/stage1', 'reducer_output_dir': None}
         >>> populate_stage("stage2", *args) # doctest: +NORMALIZE_WHITESPACE
         {'is_metadata': True, 'data_input_dir': '/c/d/stage1', 'metadata_input_dir': '/a/b/metadata',
-         'output_dir': '/c/d/stage2'}
+         'output_dir': '/c/d/stage2', 'reducer_output_dir': '/c/d/stage2'}
         >>> populate_stage("stage3", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'is_metadata': False, 'data_input_dir': '/c/d/stage1',
-         'metadata_input_dir': '/c/d/stage2', 'output_dir': '/c/d/stage3'}
+        {'is_metadata': False, 'output_dir': '/g/h', 'data_input_dir': '/c/d/stage1',
+         'metadata_input_dir': '/c/d/stage2', 'reducer_output_dir': None}
         >>> populate_stage("stage4", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'data_input_dir': '/e/f', 'output_dir': '/g/h', 'is_metadata': False,
-         'metadata_input_dir': '/c/d/stage2'}
+        {'data_input_dir': '/e/f', 'is_metadata': False,
+         'metadata_input_dir': '/c/d/stage2', 'output_dir': '/c/d/stage4', 'reducer_output_dir': None}
         >>> populate_stage("stage5", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'aggregations': ['foo'], 'is_metadata': True, 'data_input_dir': '/g/h',
-         'metadata_input_dir': '/c/d/stage2', 'output_dir': '/c/d/stage5'}
+        {'aggregations': ['foo'], 'is_metadata': True, 'data_input_dir': '/c/d/stage4',
+         'metadata_input_dir': '/c/d/stage2', 'output_dir': '/c/d/stage5',
+         'reducer_output_dir': '/c/d/metadata'}
         >>> populate_stage("stage6", *args) # doctest: +NORMALIZE_WHITESPACE
-        {'is_metadata': False, 'data_input_dir': '/g/h',
-         'metadata_input_dir': '/c/d/stage5', 'output_dir': '/c/d/stage6'}
+        {'is_metadata': False, 'data_input_dir': '/c/d/stage4',
+         'metadata_input_dir': '/c/d/stage5', 'output_dir': '/c/d/data', 'reducer_output_dir': None}
         >>> populate_stage("stage7", *args) # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
             ...
@@ -212,26 +256,66 @@ def populate_stage(
         else:
             prior_data_stage = s_resolved
 
+    # First, we set the stage's input directories. It needs to be able to read both data shards and reduced
+    # metadata files. These will either be pulled from the overall pipeline input directories or from the
+    # relevant preceding stage's output directories, as appropriate.
     is_first_data_stage = prior_data_stage is None
     is_first_metadata_stage = prior_metadata_stage is None
 
-    input_dir = Path(input_dir)
+    pipeline_input_data_dir = str(Path(input_dir) / "data")
+    pipeline_input_metadata_dir = str(Path(input_dir) / "metadata")
+
+    if is_first_data_stage:
+        default_data_input_dir = pipeline_input_data_dir
+    else:
+        default_data_input_dir = prior_data_stage["output_dir"]
+
+    if is_first_metadata_stage:
+        default_metadata_input_dir = pipeline_input_metadata_dir
+    else:
+        default_metadata_input_dir = prior_metadata_stage["output_dir"]
+
+    # Now, we need to set output directories. The output directory for the stage will either be a stage
+    # specific output directory, or, for the last data or metadata stages, respectively, will be the global
+    # pipeline output data shard or metadata directories, as appropriate.
+    is_metadata = is_metadata_stage(stage)
+
+    stage_index = stages.index(stage_name)
+
+    is_later_data_stage = False
+    is_later_metadata_stage = False
+    for i in range(stage_index + 1, len(stages)):
+        stage_i = stage_configs.get(stages[i], {})
+        if is_metadata_stage(stage_i):
+            is_later_metadata_stage = True
+        else:
+            is_later_data_stage = True
+
+    is_last_data_stage = (not is_later_data_stage) and (not is_metadata)
+    is_last_metadata_stage = (not is_later_metadata_stage) and is_metadata
+
     cohort_dir = Path(cohort_dir)
 
-    pipeline_input_data_dir = str(input_dir / "data")
-    pipeline_input_metadata_dir = str(input_dir / "metadata")
+    if is_last_data_stage:
+        default_mapper_output_dir = str(cohort_dir / "data")
+        default_reducer_output_dir = None
+    elif is_last_metadata_stage:
+        default_mapper_output_dir = str(cohort_dir / stage_name)
+        default_reducer_output_dir = str(cohort_dir / "metadata")
+    elif is_metadata:
+        default_mapper_output_dir = str(cohort_dir / stage_name)
+        default_reducer_output_dir = str(cohort_dir / stage_name)
+    else:
+        default_mapper_output_dir = str(cohort_dir / stage_name)
+        default_reducer_output_dir = None
 
     inferred_keys = {
-        "is_metadata": "aggregations" in stage,
-        "data_input_dir": pipeline_input_data_dir if is_first_data_stage else prior_data_stage["output_dir"],
-        "metadata_input_dir": (
-            pipeline_input_metadata_dir if is_first_metadata_stage else prior_metadata_stage["output_dir"]
-        ),
-        "output_dir": cohort_dir / stage_name,
+        "is_metadata": is_metadata,
+        "data_input_dir": default_data_input_dir,
+        "metadata_input_dir": default_metadata_input_dir,
+        "output_dir": default_mapper_output_dir,
+        "reducer_output_dir": default_reducer_output_dir,
     }
-
-    if "is_metadata" in stage and not isinstance(stage["is_metadata"], (bool, type(None))):
-        raise TypeError(f"If specified manually, is_metadata must be a boolean. Got {stage['is_metadata']}")
 
     out = {**stage}
     for key, val in inferred_keys.items():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -503,7 +503,7 @@ def test_extraction():
         full_stdout = "\n".join(all_stdouts)
 
         # Check the final output
-        output_folder = MEDS_cohort_dir / "final_cohort"
+        output_folder = MEDS_cohort_dir / "data"
         try:
             for split, expected_df_L in MEDS_OUTPUTS.items():
                 if not isinstance(expected_df_L, list):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -549,7 +549,7 @@ def test_extraction():
         full_stderr = "\n".join(all_stderrs)
         full_stdout = "\n".join(all_stdouts)
 
-        output_file = MEDS_cohort_dir / "code_metadata.parquet"
+        output_file = MEDS_cohort_dir / "aggregate_code_metadata" / "codes.parquet"
         assert output_file.is_file(), f"Expected {output_file} to exist: stderr:\n{stderr}\nstdout:\n{stdout}"
 
         got_df = pl.read_parquet(output_file, glob=False)
@@ -582,7 +582,7 @@ def test_extraction():
         full_stderr = "\n".join(all_stderrs)
         full_stdout = "\n".join(all_stdouts)
 
-        output_file = MEDS_cohort_dir / "code_metadata.parquet"
+        output_file = MEDS_cohort_dir / "metadata" / "codes.parquet"
         assert output_file.is_file(), f"Expected {output_file} to exist: stderr:\n{stderr}\nstdout:\n{stdout}"
 
         got_df = pl.read_parquet(output_file, glob=False)

--- a/tests/test_filter_patients.py
+++ b/tests/test_filter_patients.py
@@ -81,6 +81,6 @@ def test_filter_patients():
     single_stage_transform_tester(
         transform_script=FILTER_PATIENTS_SCRIPT,
         stage_name="filter_patients",
-        transform_stage_kwargs={"min_events_per_patient": 5, "data_input_dir": None},
+        transform_stage_kwargs={"min_events_per_patient": 5},
         want_outputs=WANT_SHARDS,
     )

--- a/tests/transform_tester_base.py
+++ b/tests/transform_tester_base.py
@@ -296,9 +296,14 @@ def single_stage_transform_tester(
         MEDS_dir = Path(d) / "MEDS_cohort"
         cohort_dir = Path(d) / "output_cohort"
 
+        MEDS_data_dir = MEDS_dir / "data"
+        MEDS_metadata_dir = MEDS_dir / "metadata"
+        cohort_metadata_dir = cohort_dir / "metadata"
+
         # Create the directories
-        MEDS_dir.mkdir()
-        cohort_dir.mkdir()
+        MEDS_data_dir.mkdir(parents=True)
+        MEDS_metadata_dir.mkdir(parents=True)
+        cohort_dir.mkdir(parents=True)
 
         # Write the splits
         splits_fp = MEDS_dir / "splits.json"
@@ -309,11 +314,11 @@ def single_stage_transform_tester(
 
         # Write the shards
         for shard_name, df in input_shards.items():
-            fp = MEDS_dir / f"{shard_name}.parquet"
+            fp = MEDS_data_dir / f"{shard_name}.parquet"
             fp.parent.mkdir(parents=True, exist_ok=True)
             df.write_parquet(fp, use_pyarrow=True)
 
-        code_metadata_fp = MEDS_dir / "code_metadata.parquet"
+        code_metadata_fp = MEDS_metadata_dir / "codes.parquet"
         if code_metadata is None:
             code_metadata = MEDS_CODE_METADATA
         elif isinstance(code_metadata, str):
@@ -342,10 +347,10 @@ def single_stage_transform_tester(
         # Check the output
         if isinstance(want_outputs, pl.DataFrame):
             # The want output is a code_metadata file in the root directory in this case.
-            check_df_output(cohort_dir / "code_metadata.parquet", want_outputs, stderr, stdout)
+            check_df_output(cohort_metadata_dir / "codes.parquet", want_outputs, stderr, stdout)
         else:
             for shard_name, want in want_outputs.items():
-                output_fp = cohort_dir / stage_name / f"{shard_name}{file_suffix}"
+                output_fp = cohort_dir / "data" / f"{shard_name}{file_suffix}"
                 if file_suffix == ".parquet":
                     check_df_output(output_fp, want, stderr, stdout)
                 elif file_suffix == ".nrt":


### PR DESCRIPTION
Closes #61 

See `pipeline_configuration.md` for an example of how input and output paths will now be inferred.