### PR TITLE
Use `MEDS_BIRTH` and `MEDS_DEATH` codes by default, per https://github.com/Medical-Event-Data-Standard/meds/blob/5f87c2fdcce7f8bab46af6f81ef7892fdee098c1/src/meds/schema.py#L26

### DIFF
--- a/MIMIC-IV_Example/configs/event_configs.yaml
+++ b/MIMIC-IV_Example/configs/event_configs.yaml
@@ -28,12 +28,6 @@ hosp/admissions:
     time_format: "%Y-%m-%d %H:%M:%S"
     hadm_id: hadm_id
   # We omit the death event here as it is joined to the data in the patients table in the pre-MEDS step.
-  #death:
-  #  code: DEATH
-  #  time: col(deathtime)
-  #  time_format: "%Y-%m-%d %H:%M:%S"
-  #  death_location: death_location
-  #  death_type: death_type
 
 hosp/diagnoses_icd:
   diagnosis:
@@ -121,11 +115,11 @@ hosp/patients:
       - col(gender)
     time: null
   dob:
-    code: DOB
+    code: MEDS_BIRTH # This is the MEDS official code for birth.
     time: col(year_of_birth)
     time_format: "%Y"
   death:
-    code: DEATH
+    code: MEDS_DEATH # This is the MEDS official code for death.
     time: col(dod)
     time_format:
       - "%Y-%m-%d %H:%M:%S"

--- a/eICU_Example/configs/event_configs.yaml
+++ b/eICU_Example/configs/event_configs.yaml
@@ -5,7 +5,7 @@ patient_id_col: patienthealthsystemstayid
 
 patient:
   dob:
-    code: "DOB"
+    code: "MEDS_BIRTH" # This is the MEDS official code for BIRTH.
     time: col(dateofbirth)
     uniquepid: "uniquepid"
   gender:

--- a/src/MEDS_transforms/configs/stage_configs/add_time_derived_measurements.yaml
+++ b/src/MEDS_transforms/configs/stage_configs/add_time_derived_measurements.yaml
@@ -1,6 +1,6 @@
 add_time_derived_measurements:
   age:
-    DOB_code: ???
+    DOB_code: "MEDS_BIRTH" # This is the MEDS official code for BIRTH
     age_code: "AGE"
     age_unit: "years"
   time_of_day:


### PR DESCRIPTION
Closes #90 