### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 110
+tab_width = 4
+
+[{*.yaml,*.yml}]
+indent_size = 2


### PR DESCRIPTION
@mmcdermott Consider adding the .editorconfig; it's useful with some IDEs like PyCharm, which I use, mostly due to the varying max line length among projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `.editorconfig` file to maintain consistent coding styles across the project.
  - Added a GitHub Actions workflow for building, publishing, and signing Python packages for distribution.
  - Enhanced the testing workflow to generate JUnit reports and upload results to Codecov.
  - Created a script to automatically generate and organize API reference pages for documentation.

- **Documentation**
  - Added new and updated documentation files, including guides for pipeline configuration and preprocessing operations.
  - Introduced a configuration file for MkDocs to enhance documentation structure and accessibility.
  - Added code coverage and documentation status badges to the main README.

- **Bug Fixes**
  - Made minor formatting adjustments in various README files to improve readability without altering content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->