### PR TITLE
Add appropriate dots into MIMIC metadata files for omop matching.

### DIFF
--- a/MIMIC-IV_Example/configs/event_configs.yaml
+++ b/MIMIC-IV_Example/configs/event_configs.yaml
@@ -42,7 +42,7 @@ hosp/diagnoses_icd:
     _metadata:
       hosp/d_icd_diagnoses:
         description: "long_title"
-        parent_codes: "ICD{icd_version}CM/{icd_code}" # Single strings are templates of columns.
+        parent_codes: "ICD{icd_version}CM/{norm_icd_code}" # Single strings are templates of columns.
 
 hosp/drgcodes:
   drg:
@@ -165,8 +165,8 @@ hosp/procedures_icd:
       hosp/d_icd_procedures:
         description: "long_title"
         parent_codes: # List of objects are string labels mapping to filters to be evaluated.
-          - "ICD{icd_version}Proc/{icd_code}": { icd_version: "9" }
-          - "ICD{icd_version}PCS/{icd_code}": { icd_version: "10" }
+          - "ICD{icd_version}Proc/{norm_icd_code}": { icd_version: "9" }
+          - "ICD{icd_version}PCS/{norm_icd_code}": { icd_version: "10" }
 
 hosp/transfers:
   transfer:

--- a/MIMIC-IV_Example/pre_MEDS.py
+++ b/MIMIC-IV_Example/pre_MEDS.py
@@ -332,8 +332,14 @@ def main(cfg: DictConfig):
 
         st = datetime.now()
         logger.info(f"Processing {pfx}...")
-        processed_df = read_fn(fp).collect().with_columns(
-            fn(pl.col("icd_version").cast(pl.String), pl.col("icd_code").cast(pl.String)).alias("icd_code")
+        processed_df = (
+            read_fn(fp)
+            .collect()
+            .with_columns(
+                fn(pl.col("icd_version").cast(pl.String), pl.col("icd_code").cast(pl.String)).alias(
+                    "norm_icd_code"
+                )
+            )
         )
         processed_df.write_parquet(out_fp, use_pyarrow=True)
         logger.info(f"  Processed and wrote to {str(out_fp.resolve())} in {datetime.now() - st}")

--- a/MIMIC-IV_Example/pre_MEDS.py
+++ b/MIMIC-IV_Example/pre_MEDS.py
@@ -266,7 +266,7 @@ def main(cfg: DictConfig):
             relative_in_fp = fp.relative_to(out_fp.resolve().parent, walk_up=True)
             out_fp.symlink_to(relative_in_fp)
             continue
-        else:
+        elif pfx in FUNCTIONS:
             out_fp = MEDS_input_dir / f"{pfx}.parquet"
             if out_fp.is_file():
                 print(f"Done with {pfx}. Continuing")

--- a/MIMIC-IV_Example/pre_MEDS.py
+++ b/MIMIC-IV_Example/pre_MEDS.py
@@ -15,6 +15,156 @@ from MEDS_transforms.extract.utils import get_supported_fp
 from MEDS_transforms.utils import get_shard_prefix, hydra_loguru_init, write_lazyframe
 
 
+def add_dot(code: pl.Expr, position: int) -> pl.Expr:
+    """Adds a dot to the code expression at the specified position.
+
+    Args:
+        code: The code expression.
+        position: The position to add the dot.
+
+    Returns:
+        The expression which would yield the code string with a dot added at the specified position
+
+    Example:
+        >>> pl.select(add_dot(pl.lit("12345"), 3))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 123.45  │
+        └─────────┘
+        >>> pl.select(add_dot(pl.lit("12345"), 1))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 1.2345  │
+        └─────────┘
+        >>> pl.select(add_dot(pl.lit("12345"), 6))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 12345   │
+        └─────────┘
+    """
+    return (
+        pl.when(code.str.len_chars() > position)
+        .then(code.str.slice(0, position) + "." + code.str.slice(position))
+        .otherwise(code)
+    )
+
+
+def add_icd_diagnosis_dot(icd_version: pl.Expr, icd_code: pl.Expr) -> pl.Expr:
+    """Adds the appropriate dot to the ICD diagnosis codebased on the version.
+
+    Args:
+        icd_version: The ICD version.
+        icd_code: The ICD code.
+
+    Returns:
+        The ICD code with appropriate dot syntax based on the version.
+
+    Examples:
+        >>> pl.select(add_icd_diagnosis_dot(pl.lit("9"), pl.lit("12345")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 123.45  │
+        └─────────┘
+        >>> pl.select(add_icd_diagnosis_dot(pl.lit("9"), pl.lit("E1234")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ E123.4  │
+        └─────────┘
+        >>> pl.select(add_icd_diagnosis_dot(pl.lit("9"), pl.lit("F1234")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ F12.34  │
+        └─────────┘
+        >>> pl.select(add_icd_diagnosis_dot(pl.lit("10"), pl.lit("12345")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 123.45  │
+        └─────────┘
+        >>> pl.select(add_icd_diagnosis_dot(pl.lit("10"), pl.lit("E1234")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ E12.34  │
+        └─────────┘
+    """
+
+    icd9_code = (
+        pl.when(icd_code.str.starts_with("E")).then(add_dot(icd_code, 4)).otherwise(add_dot(icd_code, 3))
+    )
+
+    icd10_code = add_dot(icd_code, 3)
+
+    return pl.when(icd_version == "9").then(icd9_code).otherwise(icd10_code)
+
+
+def add_icd_procedure_dot(icd_version: pl.Expr, icd_code: pl.Expr) -> pl.Expr:
+    """Adds the appropriate dot to the ICD procedure code based on the version.
+
+    Args:
+        icd_version: The ICD version.
+        icd_code: The ICD code.
+
+    Returns:
+        The ICD code with appropriate dot syntax based on the version.
+
+    Examples:
+        >>> pl.select(add_icd_procedure_dot(pl.lit("9"), pl.lit("12345")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 12.345  │
+        └─────────┘
+        >>> pl.select(add_icd_procedure_dot(pl.lit("10"), pl.lit("12345")))
+        shape: (1, 1)
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ 12345   │
+        └─────────┘
+    """
+
+    icd9_code = add_dot(icd_code, 2)
+    icd10_code = icd_code
+
+    return pl.when(icd_version == "9").then(icd9_code).otherwise(icd10_code)
+
+
 def add_discharge_time_by_hadm_id(
     df: pl.LazyFrame, discharge_time_df: pl.LazyFrame, out_column_name: str = "hadm_discharge_time"
 ) -> pl.LazyFrame:
@@ -50,6 +200,11 @@ FUNCTIONS = {
     "hosp/drgcodes": (add_discharge_time_by_hadm_id, ("hosp/admissions", ["hadm_id", "dischtime"])),
     "hosp/patients": (fix_static_data, ("hosp/admissions", ["subject_id", "deathtime"])),
 }
+
+ICD_DFS_TO_FIX = [
+    ("hosp/d_icd_diagnoses", add_icd_diagnosis_dot),
+    ("hosp/d_icd_procedures", add_icd_procedure_dot),
+]
 
 
 @hydra.main(version_base=None, config_path="configs", config_name="pre_MEDS")
@@ -104,7 +259,7 @@ def main(cfg: DictConfig):
 
         out_fp.parent.mkdir(parents=True, exist_ok=True)
 
-        if pfx not in FUNCTIONS:
+        if pfx not in FUNCTIONS and pfx not in [p for p, _ in ICD_DFS_TO_FIX]:
             logger.info(
                 f"No function needed for {pfx}: " f"Symlinking {str(fp.resolve())} to {str(out_fp.resolve())}"
             )
@@ -163,6 +318,22 @@ def main(cfg: DictConfig):
             processed_df = fn(fp_df, df)
             write_lazyframe(processed_df, out_fp)
             logger.info(f"    Processed and wrote to {str(out_fp.resolve())} in {datetime.now() - fp_st}")
+
+    for pfx, fn in ICD_DFS_TO_FIX:
+        fp, read_fn = get_supported_fp(input_dir, pfx)
+        out_fp = MEDS_input_dir / f"{pfx}.parquet"
+
+        if out_fp.is_file():
+            print(f"Done with {pfx}. Continuing")
+            continue
+
+        st = datetime.now()
+        logger.info(f"Processing {pfx}...")
+        processed_df = read_fn(fp).with_columns(
+            fn(pl.col("icd_version"), pl.col("icd_code")).alias("icd_code")
+        )
+        write_lazyframe(processed_df, out_fp)
+        logger.info(f"  Processed and wrote to {str(out_fp.resolve())} in {datetime.now() - st}")
 
     logger.info(f"Done! All dataframes processed and written to {str(MEDS_input_dir.resolve())}")
     done_fp.write_text(f"Finished at {datetime.now()}")


### PR DESCRIPTION
Closes #181. This is a bit hacky right now in some regards, but that is fine for now.