### PR TITLE
Updated the mimic iv tutorial

### DIFF
--- a/MIMIC-IV_Example/README.md
+++ b/MIMIC-IV_Example/README.md
@@ -9,7 +9,9 @@ up from this one).
 ```bash
 conda create -n meds-transform python=3.12
 conda activate meds-transform
-export VERSION=0.0.8 # or whatever version you want
+# Get the latest version of MEDS_transforms from pypi
+LATEST_VERSION=$(pip index versions "meds-transforms" 2>/dev/null | egrep -o '([0-9]+\.){2}[0-9]+' | head -n 1)
+export VERSION=LATEST_VERSION # or whatever version you want, at the time of writing this is "0.0.8"
 pip install "MEDS_transforms[local_parallelism,slurm_parallelism]==${VERSION}"
 ```
 

--- a/MIMIC-IV_Example/README.md
+++ b/MIMIC-IV_Example/README.md
@@ -7,9 +7,10 @@ up from this one).
 ## Step 0: Installation
 
 ```bash
-conda create -n MEDS python=3.12
-conda activate MEDS
-pip install "MEDS_transforms[local_parallelism,slurm_parallelism]"
+conda create -n meds-transform python=3.12
+conda activate meds-transform
+export VERSION=0.0.8 # or whatever version you want
+pip install "MEDS_transforms[local_parallelism,slurm_parallelism]==${VERSION}"
 ```
 
 If you want to profile the time and memory costs of your ETL, also install: `pip install hydra-profiler`.
@@ -17,11 +18,10 @@ If you want to profile the time and memory costs of your ETL, also install: `pip
 ## Step 0.5: Set-up
 Set some environment variables and download the necessary files:
 ```bash
-export MIMICIV_RAW_DIR=??? # set to the directory in which you want to store the raw MIMIC-IV data
-export MIMICIV_PRE_MEDS_DIR=??? # set to the directory in which you want to store the raw MIMIC-IV data
-export MIMICIV_MEDS_COHORT_DIR=??? # set to the directory in which you want to store the raw MIMIC-IV data
+export MIMICIV_RAW_DIR=/storage/shared/mimiciv/meds_tab_tutorial/raw/ # set to the directory in which you want to store the raw MIMIC-IV data
+export MIMICIV_PRE_MEDS_DIR=/storage/shared/mimiciv/meds_tab_tutorial/pre_meds/ # set to the directory in which you want to store the raw MIMIC-IV data
+export MIMICIV_MEDS_COHORT_DIR=/storage/shared/mimiciv/meds_tab_tutorial/meds/ # set to the directory in which you want to store the raw MIMIC-IV data
 
-export VERSION=0.0.6 # or whatever version you want
 export URL="https://raw.githubusercontent.com/mmcdermott/MEDS_transforms/$VERSION/MIMIC-IV_Example"
 
 wget $URL/run.sh
@@ -31,6 +31,8 @@ wget $URL/slurm_runner.yaml
 mkdir configs
 cd configs
 wget $URL/configs/extract_MIMIC.yaml
+wget $URL/configs/pre_MEDS.yaml
+wget $URL/configs/event_configs.yaml
 cd ..
 chmod +x run.sh
 chmod +x pre_MEDS.py
@@ -74,9 +76,9 @@ To use a specific stage runner file (e.g., to set different parallelism options)
 additional argument
 
 ```bash
-export N_WORKERS=5
-./run.sh $MIMICIV_RAW_DIR $MIMICIV_PRE_MEDS_DIR $MIMICIV_MEDS_DIR do_unzip=true \
-    stage_runner_fp=slurm_runner.yaml
+export N_WORKERS=8
+./run.sh $MIMICIV_RAW_DIR $MIMICIV_PRE_MEDS_DIR $MIMICIV_MEDS_DIR do_unzip=false \
+    stage_runner_fp=local_parallelism_runner.yaml
 ```
 
 The `N_WORKERS` environment variable set before the command controls how many parallel workers should be used


### PR DESCRIPTION
Now the tutorial will always use the latest version of meds-transform by default (by checking pypi for the latest version), and I included downloads all necessary config files as some were missing which broke the tutorial.