### PR TITLE
Update python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "MEDS ETL and transformation functions leveraging a sharding-based parallelism model & polars."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Doing the MIMIC-IV example in Python 3.11 gives me:
```
Traceback (most recent call last):
  File "/Users/robin/Documents/git/MEDS_transforms/MIMIC-IV_Example/pre_MEDS.py", line 266, in main
    relative_in_fp = fp.relative_to(out_fp.resolve().parent, walk_up=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PurePath.relative_to() got an unexpected keyword argument 'walk_up'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated minimum supported Python version to 3.12.
  
- **Bug Fixes**
	- Adjusted compatibility requirements for existing environments using Python 3.11 or earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->