### PR TITLE
263 drop table flag

### DIFF
--- a/src/MEDS_transforms/extract/convert_to_sharded_events.py
+++ b/src/MEDS_transforms/extract/convert_to_sharded_events.py
@@ -851,7 +851,11 @@ def main(cfg: DictConfig):
     event_conversion_cfg = OmegaConf.load(event_conversion_cfg_fp)
     logger.info(f"Event conversion config:\n{OmegaConf.to_yaml(event_conversion_cfg)}")
 
-    event_conversion_cfg.pop("tables_to_ignore", [])
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", None)
+    if tables_to_ignore:
+        logger.warning(f"Ignoring tables: {tables_to_ignore}")
+        for table in tables_to_ignore:
+            event_conversion_cfg.pop(table, None)
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
 
     subject_subsharded_dir.mkdir(parents=True, exist_ok=True)

--- a/src/MEDS_transforms/extract/convert_to_sharded_events.py
+++ b/src/MEDS_transforms/extract/convert_to_sharded_events.py
@@ -851,6 +851,7 @@ def main(cfg: DictConfig):
     event_conversion_cfg = OmegaConf.load(event_conversion_cfg_fp)
     logger.info(f"Event conversion config:\n{OmegaConf.to_yaml(event_conversion_cfg)}")
 
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
 
     subject_subsharded_dir.mkdir(parents=True, exist_ok=True)
@@ -868,6 +869,7 @@ def main(cfg: DictConfig):
     for sp, subjects in subject_splits:
         for input_prefix, event_cfgs in event_configs:
             event_cfgs = copy.deepcopy(event_cfgs)
+            logger.info(event_cfgs)
             input_subject_id_column = event_cfgs.pop("subject_id_col", default_subject_id_col)
 
             event_shards = list((input_dir / input_prefix).glob("*.parquet"))

--- a/src/MEDS_transforms/extract/convert_to_sharded_events.py
+++ b/src/MEDS_transforms/extract/convert_to_sharded_events.py
@@ -851,7 +851,7 @@ def main(cfg: DictConfig):
     event_conversion_cfg = OmegaConf.load(event_conversion_cfg_fp)
     logger.info(f"Event conversion config:\n{OmegaConf.to_yaml(event_conversion_cfg)}")
 
-    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
+    event_conversion_cfg.pop("tables_to_ignore", [])
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
 
     subject_subsharded_dir.mkdir(parents=True, exist_ok=True)

--- a/src/MEDS_transforms/extract/extract_code_metadata.py
+++ b/src/MEDS_transforms/extract/extract_code_metadata.py
@@ -306,11 +306,11 @@ def get_events_and_metadata_by_metadata_fp(event_configs: dict | DictConfig) -> 
     out = {}
 
     for file_pfx, event_cfgs_for_pfx in event_configs.items():
-        if file_pfx == "subject_id_col":
+        if file_pfx == "subject_id_col" or file_pfx == "tables_to_ignore":
             continue
 
         for event_key, event_cfg in event_cfgs_for_pfx.items():
-            if event_key == "subject_id_col":
+            if event_key == "subject_id_col" or event_key == "tables_to_ignore":
                 continue
 
             for metadata_pfx, metadata_cfg in event_cfg.get("_metadata", {}).items():

--- a/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
+++ b/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
@@ -199,7 +199,9 @@ def merge_subdirs_and_sort(
     if len(dirs_to_read := {fp.parent for fp in files_to_read}) != len(event_subsets):
         raise RuntimeError(
             "Number of found subsets ({}) does not match "
-            "number of subsets in event_config ({}): {}".format(len(dirs_to_read), len(event_subsets), sp_dir)
+            "number of subsets in event_config ({}): {}. "
+            "HINT: your raw data might not match you event_config.yaml file, please check your data or use "
+            "the ignore_tables flag ".format(len(dirs_to_read), len(event_subsets), sp_dir)
         )
 
     file_strs = "\n".join(f"  - {str(fp.resolve())}" for fp in files_to_read)
@@ -265,6 +267,11 @@ def main(cfg: DictConfig):
     """
     event_conversion_cfg = OmegaConf.load(cfg.event_conversion_config_fp)
     event_conversion_cfg.pop("subject_id_col", None)
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", None)
+    if tables_to_ignore:
+        logger.warning(f"Ignoring tables: {tables_to_ignore}")
+        for table in tables_to_ignore:
+            event_conversion_cfg.pop(table, None)
 
     read_fn = partial(
         merge_subdirs_and_sort,

--- a/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
+++ b/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
@@ -201,7 +201,7 @@ def merge_subdirs_and_sort(
             "Number of found subsets ({}) does not match "
             "number of subsets in event_config ({}): {}. "
             "HINT: your raw data might not match you event_config.yaml file, please check your data or use "
-            "the ignore_tables flag ".format(len(dirs_to_read), len(event_subsets), sp_dir)
+            "the tables_to_ignore flag ".format(len(dirs_to_read), len(event_subsets), sp_dir)
         )
 
     file_strs = "\n".join(f"  - {str(fp.resolve())}" for fp in files_to_read)

--- a/src/MEDS_transforms/extract/shard_events.py
+++ b/src/MEDS_transforms/extract/shard_events.py
@@ -227,7 +227,11 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
     prefix_to_columns = {}
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", subject_id_field)
-    event_conversion_cfg.pop("tables_to_ignore", [])
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", None)
+    if tables_to_ignore:
+        logger.warning(f"Ignoring tables: {tables_to_ignore}")
+        for table in tables_to_ignore:
+            event_conversion_cfg.pop(table, None)
 
     for input_prefix, event_cfgs in event_conversion_cfg.items():
 

--- a/src/MEDS_transforms/extract/shard_events.py
+++ b/src/MEDS_transforms/extract/shard_events.py
@@ -227,7 +227,10 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
     prefix_to_columns = {}
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", subject_id_field)
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
+
     for input_prefix, event_cfgs in event_conversion_cfg.items():
+
         input_subject_id_column = event_cfgs.pop("subject_id_col", default_subject_id_col)
 
         prefix_to_columns[input_prefix] = {input_subject_id_column}

--- a/src/MEDS_transforms/extract/shard_events.py
+++ b/src/MEDS_transforms/extract/shard_events.py
@@ -227,7 +227,7 @@ def retrieve_columns(event_conversion_cfg: DictConfig) -> dict[str, list[str]]:
     prefix_to_columns = {}
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", subject_id_field)
-    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
+    event_conversion_cfg.pop("tables_to_ignore", [])
 
     for input_prefix, event_cfgs in event_conversion_cfg.items():
 

--- a/src/MEDS_transforms/extract/split_and_shard_subjects.py
+++ b/src/MEDS_transforms/extract/split_and_shard_subjects.py
@@ -237,6 +237,8 @@ def main(cfg: DictConfig):
     dfs = []
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
+
     for input_prefix, event_cfgs in event_conversion_cfg.items():
         input_subject_id_column = event_cfgs.get("subject_id_col", default_subject_id_col)
 

--- a/src/MEDS_transforms/extract/split_and_shard_subjects.py
+++ b/src/MEDS_transforms/extract/split_and_shard_subjects.py
@@ -237,7 +237,7 @@ def main(cfg: DictConfig):
     dfs = []
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
-    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", [])
+    event_conversion_cfg.pop("tables_to_ignore", [])
 
     for input_prefix, event_cfgs in event_conversion_cfg.items():
         input_subject_id_column = event_cfgs.get("subject_id_col", default_subject_id_col)

--- a/src/MEDS_transforms/extract/split_and_shard_subjects.py
+++ b/src/MEDS_transforms/extract/split_and_shard_subjects.py
@@ -237,7 +237,11 @@ def main(cfg: DictConfig):
     dfs = []
 
     default_subject_id_col = event_conversion_cfg.pop("subject_id_col", "subject_id")
-    event_conversion_cfg.pop("tables_to_ignore", [])
+    tables_to_ignore = event_conversion_cfg.pop("tables_to_ignore", None)
+    if tables_to_ignore:
+        logger.warning(f"Ignoring tables: {tables_to_ignore}")
+        for table in tables_to_ignore:
+            event_conversion_cfg.pop(table, None)
 
     for input_prefix, event_cfgs in event_conversion_cfg.items():
         input_subject_id_column = event_cfgs.get("subject_id_col", default_subject_id_col)


### PR DESCRIPTION
Closes #263 I am not that happy with how I had to add code in multiple places, but the problem is that the event_config is read in multiple places such that we cannot remove it once. Happy to hear of a better alternative @mmcdermott 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency configuration to streamline requirements and enhance testing options.

- **Refactor**
  - Streamlined the data preprocessing workflow by removing redundant transformation stages.
  - Improved configuration handling to better manage ignored tables and enhanced logging and error messages during data merging.

- **Tests**
  - Removed outdated tests related to the removed transformation stages and updated test configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->