### PR TITLE
fix: remove mutable default argument in shard_subjects

### DIFF
--- a/src/MEDS_transforms/extract/split_and_shard_subjects.py
+++ b/src/MEDS_transforms/extract/split_and_shard_subjects.py
@@ -20,7 +20,7 @@ def shard_subjects(
     subjects: np.ndarray,
     n_subjects_per_shard: int = 50000,
     external_splits: dict[str, Sequence[int]] | None = None,
-    split_fracs_dict: dict[str, float] | None = {"train": 0.8, "tuning": 0.1, "held_out": 0.1},
+    split_fracs_dict: dict[str, float] | None = None,
     seed: int = 1,
 ) -> dict[str, list[int]]:
     """Shard a list of subjects, nested within train/tuning/held-out splits.
@@ -93,6 +93,8 @@ def shard_subjects(
         >>> shard_subjects(subjects, 3, external_splits)
         {'train/0': [5, 1, 3], 'train/1': [2, 6, 4], 'test/0': [10, 7], 'test/1': [8, 9]}
     """
+    if split_fracs_dict is None:
+        split_fracs_dict = {"train": 0.8, "tuning": 0.1, "held_out": 0.1}
 
     if external_splits is None:
         external_splits = {}


### PR DESCRIPTION
Replace the mutable dictionary default argument with None to avoid the 
common Python pitfall where default mutable arguments are created once 
at function definition time. Default split fractions are now assigned 
within the function body when split_fracs_dict is None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the flexibility of data splitting configurations. Now, if custom split fractions aren’t provided, standard values are automatically applied. This change streamlines configuration and continues to enforce robust error checking for invalid split inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->