### PR TITLE
Moved mapreduce imports to be from the sub-module, not individual files.

### DIFF
--- a/src/MEDS_transforms/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/aggregate_code_metadata.py
@@ -16,8 +16,7 @@ from meds import subject_id_field
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
-from MEDS_transforms.mapreduce.utils import is_complete_parquet_file
+from MEDS_transforms.mapreduce import is_complete_parquet_file, map_over
 from MEDS_transforms.utils import write_lazyframe
 
 logger = logging.getLogger(__name__)

--- a/src/MEDS_transforms/extract/convert_to_sharded_events.py
+++ b/src/MEDS_transforms/extract/convert_to_sharded_events.py
@@ -16,7 +16,7 @@ from omegaconf.listconfig import ListConfig
 
 from MEDS_transforms.extract import CONFIG_YAML
 from MEDS_transforms.extract.shard_events import META_KEYS
-from MEDS_transforms.mapreduce.mapper import rwlock_wrap
+from MEDS_transforms.mapreduce import rwlock_wrap
 from MEDS_transforms.utils import is_col_field, parse_col_field, stage_init, write_lazyframe
 
 logger = logging.getLogger(__name__)

--- a/src/MEDS_transforms/extract/extract_code_metadata.py
+++ b/src/MEDS_transforms/extract/extract_code_metadata.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 from MEDS_transforms.extract import CONFIG_YAML, MEDS_METADATA_MANDATORY_TYPES
 from MEDS_transforms.extract.convert_to_sharded_events import get_code_expr
 from MEDS_transforms.extract.utils import get_supported_fp
-from MEDS_transforms.mapreduce.mapper import rwlock_wrap
+from MEDS_transforms.mapreduce import rwlock_wrap
 from MEDS_transforms.parser import cfg_to_expr
 from MEDS_transforms.utils import stage_init, write_lazyframe
 

--- a/src/MEDS_transforms/extract/finalize_MEDS_data.py
+++ b/src/MEDS_transforms/extract/finalize_MEDS_data.py
@@ -9,7 +9,7 @@ from meds import data_schema
 from omegaconf import DictConfig
 
 from MEDS_transforms.extract import CONFIG_YAML, MEDS_DATA_MANDATORY_TYPES
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 
 def get_and_validate_data_schema(df: pl.LazyFrame, stage_cfg: DictConfig) -> pa.Table:

--- a/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
+++ b/src/MEDS_transforms/extract/merge_to_MEDS_cohort.py
@@ -8,8 +8,7 @@ import polars as pl
 from omegaconf import DictConfig, OmegaConf
 
 from MEDS_transforms.extract import CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
-from MEDS_transforms.mapreduce.utils import shard_iterator_by_shard_map
+from MEDS_transforms.mapreduce import map_over, shard_iterator_by_shard_map
 
 logger = logging.getLogger(__name__)
 

--- a/src/MEDS_transforms/extract/shard_events.py
+++ b/src/MEDS_transforms/extract/shard_events.py
@@ -15,7 +15,7 @@ from meds import subject_id_field
 from omegaconf import DictConfig, OmegaConf
 
 from MEDS_transforms.extract import CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import rwlock_wrap
+from MEDS_transforms.mapreduce import rwlock_wrap
 from MEDS_transforms.utils import get_shard_prefix, is_col_field, parse_col_field, write_lazyframe
 
 logger = logging.getLogger(__name__)

--- a/src/MEDS_transforms/filters/filter_measurements.py
+++ b/src/MEDS_transforms/filters/filter_measurements.py
@@ -7,7 +7,7 @@ import polars as pl
 from omegaconf import DictConfig
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 
 def filter_measurements_fntr(

--- a/src/MEDS_transforms/filters/filter_subjects.py
+++ b/src/MEDS_transforms/filters/filter_subjects.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig
 logger = logging.getLogger(__name__)
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 
 def filter_subjects_by_num_measurements(df: pl.LazyFrame, min_measurements_per_subject: int) -> pl.LazyFrame:

--- a/src/MEDS_transforms/mapreduce/__init__.py
+++ b/src/MEDS_transforms/mapreduce/__init__.py
@@ -1,0 +1,17 @@
+from .mapper import map_over  # noqa: F401
+from .utils import (  # noqa: F401
+    is_complete_parquet_file,
+    rwlock_wrap,
+    shard_iterator,
+    shard_iterator_by_shard_map,
+    shuffle_shards,
+)
+
+__all__ = [
+    "map_over",
+    "is_complete_parquet_file",
+    "shard_iterator_by_shard_map",
+    "rwlock_wrap",
+    "shard_iterator",
+    "shuffle_shards",
+]

--- a/src/MEDS_transforms/reshard_to_split.py
+++ b/src/MEDS_transforms/reshard_to_split.py
@@ -15,7 +15,7 @@ from omegaconf import DictConfig
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
 from MEDS_transforms.extract.split_and_shard_subjects import shard_subjects
-from MEDS_transforms.mapreduce.utils import rwlock_wrap, shard_iterator, shuffle_shards
+from MEDS_transforms.mapreduce import rwlock_wrap, shard_iterator, shuffle_shards
 from MEDS_transforms.utils import stage_init, write_lazyframe
 
 logger = logging.getLogger(__name__)

--- a/src/MEDS_transforms/transforms/add_time_derived_measurements.py
+++ b/src/MEDS_transforms/transforms/add_time_derived_measurements.py
@@ -8,7 +8,7 @@ import polars as pl
 from omegaconf import DictConfig, OmegaConf
 
 from MEDS_transforms import INFERRED_STAGE_KEYS, PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 logger = logging.getLogger(__name__)
 

--- a/src/MEDS_transforms/transforms/extract_values.py
+++ b/src/MEDS_transforms/transforms/extract_values.py
@@ -9,7 +9,7 @@ from meds import subject_id_field
 from omegaconf import DictConfig
 
 from MEDS_transforms import DEPRECATED_NAMES, INFERRED_STAGE_KEYS, MANDATORY_TYPES, PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 from MEDS_transforms.parser import cfg_to_expr
 
 logger = logging.getLogger(__name__)

--- a/src/MEDS_transforms/transforms/normalization.py
+++ b/src/MEDS_transforms/transforms/normalization.py
@@ -7,7 +7,7 @@ import polars as pl
 from omegaconf import DictConfig
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 
 def normalize(

--- a/src/MEDS_transforms/transforms/occlude_outliers.py
+++ b/src/MEDS_transforms/transforms/occlude_outliers.py
@@ -7,7 +7,7 @@ import polars as pl
 from omegaconf import DictConfig
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 
 
 def occlude_outliers_fntr(

--- a/src/MEDS_transforms/transforms/reorder_measurements.py
+++ b/src/MEDS_transforms/transforms/reorder_measurements.py
@@ -8,7 +8,7 @@ import polars as pl
 from omegaconf import DictConfig, ListConfig
 
 from MEDS_transforms import PREPROCESS_CONFIG_YAML
-from MEDS_transforms.mapreduce.mapper import map_over
+from MEDS_transforms.mapreduce import map_over
 from MEDS_transforms.utils import get_smallest_valid_uint_type
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This will enable a minor release that will let downstream users implementing their own transformations be more robust to upcoming changes to mapreduce file organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the organization of dependency imports to reduce redundancy and improve code clarity.
  - Enhanced overall maintainability without changing visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->