### PR TITLE
Unified the run entry point to a single function and interface, leveraging MEDS_transforms.stage entry points to get stages.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,19 +35,22 @@ docs = [
 
 [project.scripts]
 # Stages
-MEDS_transform-aggregate_code_metadata = "MEDS_transforms.stages.aggregate_code_metadata:main"
-MEDS_transform-fit_vocabulary_indices = "MEDS_transforms.stages.fit_vocabulary_indices:main"
-MEDS_transform-reshard_to_split = "MEDS_transforms.stages.reshard_to_split:main"
-MEDS_transform-filter_measurements = "MEDS_transforms.stages.filter_measurements:filter_measurements.main"
-MEDS_transform-filter_subjects = "MEDS_transforms.stages.filter_subjects:filter_subjects.main"
-MEDS_transform-reorder_measurements = "MEDS_transforms.stages.reorder_measurements:reorder_measurements.main"
-MEDS_transform-add_time_derived_measurements = "MEDS_transforms.stages.add_time_derived_measurements:add_time_derived_measurements.main"
-MEDS_transform-extract_values = "MEDS_transforms.stages.extract_values:extract_values.main"
-MEDS_transform-normalization = "MEDS_transforms.stages.normalization:normalize.main"
-MEDS_transform-occlude_outliers = "MEDS_transforms.stages.occlude_outliers:occlude_outliers.main"
+MEDS_transform-stage = "MEDS_transforms.__main__:run_stage"
 
 # Runner
-MEDS_transform-runner = "MEDS_transforms.runner:main"
+MEDS_transform-pipeline = "MEDS_transforms.runner:main"
+
+[project.entry-points."MEDS_transforms.stages"]
+aggregate_code_metadata = "MEDS_transforms.stages.aggregate_code_metadata:main"
+fit_vocabulary_indices = "MEDS_transforms.stages.fit_vocabulary_indices:main"
+reshard_to_split = "MEDS_transforms.stages.reshard_to_split:main"
+filter_measurements = "MEDS_transforms.stages.filter_measurements:filter_measurements.main"
+filter_subjects = "MEDS_transforms.stages.filter_subjects:filter_subjects.main"
+reorder_measurements = "MEDS_transforms.stages.reorder_measurements:reorder_measurements.main"
+add_time_derived_measurements = "MEDS_transforms.stages.add_time_derived_measurements:add_time_derived_measurements.main"
+extract_values = "MEDS_transforms.stages.extract_values:extract_values.main"
+normalization = "MEDS_transforms.stages.normalization:normalize.main"
+occlude_outliers = "MEDS_transforms.stages.occlude_outliers:occlude_outliers.main"
 
 [project.urls]
 Homepage = "https://github.com/mmcdermott/MEDS_transforms"

--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -1,0 +1,35 @@
+import sys
+from importlib.metadata import entry_points
+
+from . import __package_name__
+
+
+def get_all_stages():
+    """Get all available stages."""
+    eps = entry_points(group=f"{__package_name__}.stages")
+    return {name: eps[name] for name in eps.names}
+
+
+def run_stage():
+    """Run a stage based on command line arguments."""
+
+    all_stages = get_all_stages()
+
+    if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h"):
+        print(f"Usage: {sys.argv[0]} <stage_name> [args]")
+        print("Available stages:")
+        for name in all_stages:
+            print(f"  - {name}")
+        sys.exit(1)
+
+    stage_name = sys.argv[1]
+    sys.argv = sys.argv[1:]  # remove dispatcher argument
+
+    if stage_name not in all_stages:
+        raise ValueError(f"Stage '{stage_name}' not found.")
+
+    main_fn = all_stages[stage_name].load()
+    if not callable(main_fn):
+        raise ValueError(f"Stage '{stage_name}' does not have a callable main function.")
+
+    main_fn()

--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -18,9 +18,12 @@ def run_stage():
     if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h"):
         print(f"Usage: {sys.argv[0]} <stage_name> [args]")
         print("Available stages:")
-        for name in all_stages:
+        for name in sorted(all_stages):
             print(f"  - {name}")
-        sys.exit(1)
+        if len(sys.argv) < 2:
+            sys.exit(1)
+        else:
+            sys.exit(0)
 
     stage_name = sys.argv[1]
     sys.argv = sys.argv[1:]  # remove dispatcher argument
@@ -29,7 +32,4 @@ def run_stage():
         raise ValueError(f"Stage '{stage_name}' not found.")
 
     main_fn = all_stages[stage_name].load()
-    if not callable(main_fn):
-        raise ValueError(f"Stage '{stage_name}' does not have a callable main function.")
-
     main_fn()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,50 +1,16 @@
-import os
+# Runner
+RUNNER_SCRIPT = "MEDS_transform-pipeline"
 
-import rootutils
+# Stages
+__stage_pattern = "MEDS_transform-stage {stage_name}"
 
-root = rootutils.setup_root(__file__, dotenv=True, pythonpath=True, cwd=True)
-
-code_root = root / "src" / "MEDS_transforms"
-transforms_root = code_root / "transforms"
-filters_root = code_root / "filters"
-
-USE_LOCAL_SCRIPTS = os.environ.get("DO_USE_LOCAL_SCRIPTS", "0") == "1"
-
-if USE_LOCAL_SCRIPTS:
-    # Runner
-    RUNNER_SCRIPT = code_root / "runner.py"
-
-    # Root Source
-    AGGREGATE_CODE_METADATA_SCRIPT = code_root / "aggregate_code_metadata.py"
-    FIT_VOCABULARY_INDICES_SCRIPT = code_root / "fit_vocabulary_indices.py"
-    RESHARD_TO_SPLIT_SCRIPT = code_root / "reshard_to_split.py"
-
-    # Filters
-    FILTER_MEASUREMENTS_SCRIPT = filters_root / "filter_measurements.py"
-    FILTER_SUBJECTS_SCRIPT = filters_root / "filter_subjects.py"
-
-    # Transforms
-    ADD_TIME_DERIVED_MEASUREMENTS_SCRIPT = transforms_root / "add_time_derived_measurements.py"
-    REORDER_MEASUREMENTS_SCRIPT = transforms_root / "reorder_measurements.py"
-    EXTRACT_VALUES_SCRIPT = transforms_root / "extract_values.py"
-    NORMALIZATION_SCRIPT = transforms_root / "normalization.py"
-    OCCLUDE_OUTLIERS_SCRIPT = transforms_root / "occlude_outliers.py"
-else:
-    # Runner
-    RUNNER_SCRIPT = "MEDS_transform-runner"
-
-    # Root Source
-    AGGREGATE_CODE_METADATA_SCRIPT = "MEDS_transform-aggregate_code_metadata"
-    FIT_VOCABULARY_INDICES_SCRIPT = "MEDS_transform-fit_vocabulary_indices"
-    RESHARD_TO_SPLIT_SCRIPT = "MEDS_transform-reshard_to_split"
-
-    # Filters
-    FILTER_MEASUREMENTS_SCRIPT = "MEDS_transform-filter_measurements"
-    FILTER_SUBJECTS_SCRIPT = "MEDS_transform-filter_subjects"
-
-    # Transforms
-    ADD_TIME_DERIVED_MEASUREMENTS_SCRIPT = "MEDS_transform-add_time_derived_measurements"
-    REORDER_MEASUREMENTS_SCRIPT = "MEDS_transform-reorder_measurements"
-    EXTRACT_VALUES_SCRIPT = "MEDS_transform-extract_values"
-    NORMALIZATION_SCRIPT = "MEDS_transform-normalization"
-    OCCLUDE_OUTLIERS_SCRIPT = "MEDS_transform-occlude_outliers"
+AGGREGATE_CODE_METADATA_SCRIPT = __stage_pattern.format(stage_name="aggregate_code_metadata")
+FIT_VOCABULARY_INDICES_SCRIPT = __stage_pattern.format(stage_name="fit_vocabulary_indices")
+RESHARD_TO_SPLIT_SCRIPT = __stage_pattern.format(stage_name="reshard_to_split")
+FILTER_MEASUREMENTS_SCRIPT = __stage_pattern.format(stage_name="filter_measurements")
+FILTER_SUBJECTS_SCRIPT = __stage_pattern.format(stage_name="filter_subjects")
+ADD_TIME_DERIVED_MEASUREMENTS_SCRIPT = __stage_pattern.format(stage_name="add_time_derived_measurements")
+REORDER_MEASUREMENTS_SCRIPT = __stage_pattern.format(stage_name="reorder_measurements")
+EXTRACT_VALUES_SCRIPT = __stage_pattern.format(stage_name="extract_values")
+NORMALIZATION_SCRIPT = __stage_pattern.format(stage_name="normalization")
+OCCLUDE_OUTLIERS_SCRIPT = __stage_pattern.format(stage_name="occlude_outliers")

--- a/tests/test_add_time_derived_measurements.py
+++ b/tests/test_add_time_derived_measurements.py
@@ -1,8 +1,4 @@
-"""Tests the add time derived measurements script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the add time derived measurements script."""
 
 from meds import subject_id_field
 

--- a/tests/test_aggregate_code_metadata.py
+++ b/tests/test_aggregate_code_metadata.py
@@ -1,8 +1,4 @@
-"""Tests the aggregate_code_metadata.py script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the aggregate_code_metadata.py script."""
 
 import polars as pl
 

--- a/tests/test_extract_values.py
+++ b/tests/test_extract_values.py
@@ -1,8 +1,4 @@
-"""Tests the extract values script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the extract values script."""
 
 from tests import EXTRACT_VALUES_SCRIPT
 from tests.transform_tester_base import parse_shards_yaml, single_stage_transform_tester

--- a/tests/test_filter_measurements.py
+++ b/tests/test_filter_measurements.py
@@ -1,8 +1,4 @@
-"""Tests the filter measurements script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the filter measurements script."""
 
 from tests import FILTER_MEASUREMENTS_SCRIPT
 from tests.transform_tester_base import single_stage_transform_tester

--- a/tests/test_filter_subjects.py
+++ b/tests/test_filter_subjects.py
@@ -1,8 +1,4 @@
-"""Tests the filter subjects script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the filter subjects script."""
 
 from meds import subject_id_field
 

--- a/tests/test_fit_vocabulary_indices.py
+++ b/tests/test_fit_vocabulary_indices.py
@@ -1,8 +1,4 @@
-"""Tests the fit vocabulary indices script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the fit vocabulary indices script."""
 
 from tests import FIT_VOCABULARY_INDICES_SCRIPT
 from tests.transform_tester_base import parse_code_metadata_csv, single_stage_transform_tester

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+import subprocess
+
+
+def test_stage_entry_point_help():
+    result = subprocess.run("MEDS_transform-stage", check=False, shell=True, capture_output=True)
+    assert result.returncode != 0
+
+    help_str = result.stdout.decode()
+    assert "Usage: " in help_str and "Available stages:" in help_str
+
+    result = subprocess.run("MEDS_transform-stage --help", check=False, shell=True, capture_output=True)
+    assert result.returncode == 0
+    assert result.stdout.decode() == help_str
+
+
+def test_stage_entry_point_invalid():
+    result = subprocess.run(
+        "MEDS_transform-stage invalid_stage", check=False, shell=True, capture_output=True
+    )
+    assert result.returncode != 0
+    assert "Stage 'invalid_stage' not found." in result.stderr.decode()

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,8 +1,4 @@
-"""Tests the normalization script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the normalization script."""
 
 import polars as pl
 

--- a/tests/test_occlude_outliers.py
+++ b/tests/test_occlude_outliers.py
@@ -1,8 +1,4 @@
-"""Tests the occlude outliers script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the occlude outliers script."""
 
 import polars as pl
 

--- a/tests/test_reorder_measurements.py
+++ b/tests/test_reorder_measurements.py
@@ -1,8 +1,4 @@
-"""Tests the reorder_measurements script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the reorder_measurements script."""
 
 from tests import REORDER_MEASUREMENTS_SCRIPT
 from tests.transform_tester_base import single_stage_transform_tester

--- a/tests/test_reshard_to_split.py
+++ b/tests/test_reshard_to_split.py
@@ -1,8 +1,4 @@
-"""Tests the reshard to split script.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Tests the reshard to split script."""
 
 from meds import subject_id_field
 

--- a/tests/test_with_runner.py
+++ b/tests/test_with_runner.py
@@ -1,8 +1,5 @@
 """Tests a multi-stage pre-processing pipeline via the Runner utility. Only checks final outputs.
 
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-
 In this test, the following stages are run:
   - filter_subjects
   - add_time_derived_measurements
@@ -20,16 +17,7 @@ from functools import partial
 import polars as pl
 from meds import code_metadata_filepath, subject_id_field, subject_splits_filepath
 
-from tests import (
-    ADD_TIME_DERIVED_MEASUREMENTS_SCRIPT,
-    AGGREGATE_CODE_METADATA_SCRIPT,
-    FILTER_SUBJECTS_SCRIPT,
-    FIT_VOCABULARY_INDICES_SCRIPT,
-    NORMALIZATION_SCRIPT,
-    OCCLUDE_OUTLIERS_SCRIPT,
-    RUNNER_SCRIPT,
-    USE_LOCAL_SCRIPTS,
-)
+from tests import AGGREGATE_CODE_METADATA_SCRIPT, RUNNER_SCRIPT
 from tests.transform_tester_base import MEDS_SHARDS, SPLITS_DF
 from tests.utils import add_params, exact_str_regex, parse_shards_yaml, single_stage_tester
 
@@ -836,31 +824,10 @@ WANT_NORMALIZATION = parse_shards_yaml(
 
 # Normally, you wouldn't need to specify all of these scripts, but in testing with local scripts we need to
 # specify them all as they need to point to their python paths.
-if USE_LOCAL_SCRIPTS:
-    STAGE_RUNNER_YAML = f"""
-filter_subjects:
-  script: "python {FILTER_SUBJECTS_SCRIPT}"
-
-add_time_derived_measurements:
-  script: "python {ADD_TIME_DERIVED_MEASUREMENTS_SCRIPT}"
-
-occlude_outliers:
-  script: "python {OCCLUDE_OUTLIERS_SCRIPT}"
-
-fit_normalization:
-  script: "python {AGGREGATE_CODE_METADATA_SCRIPT}"
-
-fit_vocabulary_indices:
-  script: "python {FIT_VOCABULARY_INDICES_SCRIPT}"
-
-normalization:
-  script: "python {NORMALIZATION_SCRIPT}"
-    """
-else:
-    STAGE_RUNNER_YAML = f"""
+STAGE_RUNNER_YAML = f"""
 fit_normalization:
   script: {AGGREGATE_CODE_METADATA_SCRIPT}
-    """
+"""
 
 PARALLEL_STAGE_RUNNER_YAML = f"""
 parallelize:
@@ -910,7 +877,7 @@ stage_configs:
       time_of_day_code: "TIME_OF_DAY"
       endpoints: [6, 12, 18, 24]
   fit_outlier_detection:
-    _script: {("python " if USE_LOCAL_SCRIPTS else "") + str(AGGREGATE_CODE_METADATA_SCRIPT)}
+    _script: {str(AGGREGATE_CODE_METADATA_SCRIPT)}
     aggregations:
       - "values/n_occurrences"
       - "values/sum"

--- a/tests/transform_tester_base.py
+++ b/tests/transform_tester_base.py
@@ -1,8 +1,4 @@
-"""Base helper code and data inputs for all transforms integration tests.
-
-Set the bash env variable `DO_USE_LOCAL_SCRIPTS=1` to use the local py files, rather than the installed
-scripts.
-"""
+"""Base helper code and data inputs for all transforms integration tests."""
 
 from collections import defaultdict
 from io import StringIO


### PR DESCRIPTION
Also removes the capability of local testing, which isn't used anymore.

Closes #280 #279 and #272 

Also renames the runner script to `pipeline` in contrast to the `stage` script exposed for singleton stage running.