### PR TITLE
Change stage registration to register stages without an explicit pipeline and pass the pipeline file on the command line.

### DIFF
--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -1,7 +1,17 @@
+import os
 import sys
 from importlib.metadata import entry_points
+from importlib.resources import files
+from pathlib import Path
+
+import hydra
+from omegaconf import OmegaConf
 
 from . import __package_name__
+
+HELP_STRS = {"--help", "-h", "help", "h"}
+PKG_PFX = "pkg://"
+YAML_EXTENSIONS = {"yaml", "yml"}
 
 
 def get_all_stages():
@@ -10,26 +20,82 @@ def get_all_stages():
     return {name: eps[name] for name in eps.names}
 
 
+def print_help_stage():
+    """Print help for all stages."""
+    print(f"Usage: {sys.argv[0]} <pipeline_yaml> <stage_name> [args]")
+    print(
+        "  * pipeline_yaml: Path to the pipeline YAML file on disk or in the "
+        f"'{PKG_PFX}<pkg_name>.<relative_path>' format."
+    )
+    print("  * stage_name: Name of the stage to run.")
+    print()
+    print("Available stages:")
+    all_stages = get_all_stages()
+    for name in sorted(all_stages):
+        print(f"  - {name}")
+
+
+def resolve_pipeline_yaml(pipeline_yaml: str):
+    """Resolve the pipeline YAML file path."""
+    if pipeline_yaml.startswith(PKG_PFX):
+        pipeline_yaml = pipeline_yaml[len(PKG_PFX) :]
+        pipeline_parts = pipeline_yaml.split(".")
+
+        if pipeline_parts[-1] not in YAML_EXTENSIONS:
+            raise ValueError(
+                f"Invalid pipeline YAML path '{pipeline_yaml}'. "
+                f"Expected a file with one of the following extensions: {YAML_EXTENSIONS}"
+            )
+
+        pkg_name = pipeline_parts[0]
+        suffix = pipeline_parts[-1]
+        relative_path = Path(os.path.join(*pipeline_parts[1:-1])).with_suffix(f".{suffix}")
+
+        try:
+            pipeline_yaml = files(pkg_name) / relative_path
+        except ImportError:
+            raise ValueError(f"Package '{pkg_name}' not found. Please check the package name.")
+    else:
+        pipeline_yaml = Path(pipeline_yaml)
+
+    if not pipeline_yaml.is_file():
+        raise FileNotFoundError(f"Pipeline YAML file '{pipeline_yaml}' does not exist.")
+
+    return pipeline_yaml
+
+
 def run_stage():
     """Run a stage based on command line arguments."""
 
     all_stages = get_all_stages()
 
-    if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h"):
-        print(f"Usage: {sys.argv[0]} <stage_name> [args]")
-        print("Available stages:")
-        for name in sorted(all_stages):
-            print(f"  - {name}")
-        if len(sys.argv) < 2:
-            sys.exit(1)
-        else:
-            sys.exit(0)
+    if sys.argv[1] in HELP_STRS:
+        print_help_stage()
+        sys.exit(0)
 
-    stage_name = sys.argv[1]
-    sys.argv = sys.argv[1:]  # remove dispatcher argument
+    elif len(sys.argv) < 3:
+        print_help_stage()
+        sys.exit(1)
+
+    pipeline_yaml = resolve_pipeline_yaml(sys.argv[1])
+    stage_name = sys.argv[2]
+    sys.argv = sys.argv[2:]  # remove dispatcher arguments
 
     if stage_name not in all_stages:
         raise ValueError(f"Stage '{stage_name}' not found.")
 
     main_fn = all_stages[stage_name].load()
-    main_fn()
+
+    print(f"Using config path: {pipeline_yaml.parent}")
+    print(f"Using config name: {pipeline_yaml.stem}")
+
+    hydra_wrapper = hydra.main(
+        version_base=None,
+        config_path=str(pipeline_yaml.parent),
+        config_name=pipeline_yaml.stem,
+    )
+
+    OmegaConf.register_new_resolver("stage_name", lambda: stage_name)
+    OmegaConf.register_new_resolver("stage_docstring", lambda: main_fn.__doc__.replace("$", "$$"))
+
+    hydra_wrapper(main_fn)()

--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -69,10 +69,12 @@ def run_stage():
 
     all_stages = get_all_stages()
 
-    if sys.argv[1] in HELP_STRS:
+    if len(sys.argv) < 2:
+        print_help_stage()
+        sys.exit(1)
+    elif sys.argv[1] in HELP_STRS:
         print_help_stage()
         sys.exit(0)
-
     elif len(sys.argv) < 3:
         print_help_stage()
         sys.exit(1)
@@ -85,9 +87,6 @@ def run_stage():
         raise ValueError(f"Stage '{stage_name}' not found.")
 
     main_fn = all_stages[stage_name].load()
-
-    print(f"Using config path: {pipeline_yaml.parent}")
-    print(f"Using config name: {pipeline_yaml.stem}")
 
     hydra_wrapper = hydra.main(
         version_base=None,

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -155,8 +155,11 @@ def run_stage(
         ...     },
         ... })
         >>> run_stage(cfg, "reshard_to_split", runner_fn=fake_shell_succeed)
-        MEDS_transform-stage reshard_to_split --config-dir=... --config-name=pipeline_config
-            'hydra.searchpath=[pkg://MEDS_transforms.configs]' stage=reshard_to_split
+        MEDS_transform-stage pipeline_config.yaml reshard_to_split
+            --config-dir=...
+            --config-name=pipeline_config
+            'hydra.searchpath=[pkg://MEDS_transforms.configs]'
+            stage=reshard_to_split
         >>> run_stage(
         ...     cfg, "fit_vocabulary_indices", runner_fn=fake_shell_succeed
         ... )
@@ -195,7 +198,7 @@ def run_stage(
     elif "_script" in stage_config:
         script = stage_config._script
     else:
-        script = f"MEDS_transform-stage {stage_name}"
+        script = f"MEDS_transform-stage {str(pipeline_config_fp)} {stage_name}"
 
     command_parts = [
         script,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 RUNNER_SCRIPT = "MEDS_transform-pipeline"
 
 # Stages
-__stage_pattern = "MEDS_transform-stage {stage_name}"
+__stage_pattern = "MEDS_transform-stage pkg://MEDS_transforms.configs._preprocess.yaml {stage_name}"
 
 AGGREGATE_CODE_METADATA_SCRIPT = __stage_pattern.format(stage_name="aggregate_code_metadata")
 FIT_VOCABULARY_INDICES_SCRIPT = __stage_pattern.format(stage_name="fit_vocabulary_indices")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,9 +13,20 @@ def test_stage_entry_point_help():
     assert result.stdout.decode() == help_str
 
 
-def test_stage_entry_point_invalid():
+def test_stage_entry_point_stage_invalid():
     result = subprocess.run(
-        "MEDS_transform-stage invalid_stage", check=False, shell=True, capture_output=True
+        "MEDS_transform-stage pkg://MEDS_transforms.configs._preprocess.yaml invalid_stage",
+        check=False,
+        shell=True,
+        capture_output=True,
     )
     assert result.returncode != 0
     assert "Stage 'invalid_stage' not found." in result.stderr.decode()
+
+
+def test_stage_entry_point_pipeline_invalid():
+    result = subprocess.run(
+        "MEDS_transform-stage not_real.yaml occlude_outliers", check=False, shell=True, capture_output=True
+    )
+    assert result.returncode != 0
+    assert "Pipeline YAML file 'not_real.yaml' does not exist." in result.stderr.decode()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,8 @@
+import re
 import subprocess
+
+SCRIPT_TEMPLATE = "MEDS_transform-stage {pipeline} {stage_name}"
+PKG_BASE = "pkg://MEDS_transforms.configs.{config}"
 
 
 def test_stage_entry_point_help():
@@ -12,21 +16,30 @@ def test_stage_entry_point_help():
     assert result.returncode == 0
     assert result.stdout.decode() == help_str
 
-
-def test_stage_entry_point_stage_invalid():
-    result = subprocess.run(
-        "MEDS_transform-stage pkg://MEDS_transforms.configs._preprocess.yaml invalid_stage",
-        check=False,
-        shell=True,
-        capture_output=True,
-    )
+    result = subprocess.run("MEDS_transform-stage foo", check=False, shell=True, capture_output=True)
     assert result.returncode != 0
-    assert "Stage 'invalid_stage' not found." in result.stderr.decode()
+    assert result.stdout.decode() == help_str
 
 
-def test_stage_entry_point_pipeline_invalid():
-    result = subprocess.run(
-        "MEDS_transform-stage not_real.yaml occlude_outliers", check=False, shell=True, capture_output=True
-    )
-    assert result.returncode != 0
-    assert "Pipeline YAML file 'not_real.yaml' does not exist." in result.stderr.decode()
+def test_stage_entry_point_errors():
+    for pipeline, stage, want_err in [
+        ("not_real.yaml", "occlude_outliers", "Pipeline YAML file 'not_real.yaml' does not exist."),
+        (PKG_BASE.format(config="_preprocess.yaml"), "not_real_stage", "Stage 'not_real_stage' not found."),
+        (
+            "pkg://pkg.bad_suffix.json",
+            "occlude_outliers",
+            re.compile("Invalid pipeline YAML path .* Expected a file with one of the following extensions"),
+        ),
+        (
+            "pkg://non_existent_pkg.file.yaml",
+            "occlude_outliers",
+            re.compile("Package 'non_existent_pkg' not found"),
+        ),
+    ]:
+        script = SCRIPT_TEMPLATE.format(pipeline=pipeline, stage_name=stage)
+        result = subprocess.run(script, check=False, shell=True, capture_output=True)
+        assert result.returncode != 0
+        if isinstance(want_err, str):
+            assert want_err in result.stderr.decode()
+        else:
+            assert re.search(want_err, result.stderr.decode()) is not None


### PR DESCRIPTION
This better aligns with the fact that stages should be usable across many pipelines, not a single one that is known at registration time.

Closes #285 