### PR TITLE
Stages should be objects, not functions with variables attached.

### DIFF
--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -79,7 +79,8 @@ def run_stage():
     if stage_name not in all_stages:
         raise ValueError(f"Stage '{stage_name}' not found.")
 
-    main_fn = all_stages[stage_name].load()
+    stage = all_stages[stage_name].load()
+    main_fn = stage.main
 
     hydra_wrapper = hydra.main(
         version_base=None,

--- a/src/MEDS_transforms/stages/__init__.py
+++ b/src/MEDS_transforms/stages/__init__.py
@@ -7,16 +7,16 @@ from .examples import StageExample, get_nested_test_cases  # noqa: F401
 # Here are all the stages that are registered in the entry points, imported here so they can be imported at a
 # module level.
 # isort: split
-from .add_time_derived_measurements import main as add_time_derived_measurements  # noqa: F401
-from .aggregate_code_metadata import main as aggregate_code_metadata  # noqa: F401
-from .extract_values import main as extract_values  # noqa: F401
-from .filter_measurements import main as filter_measurements  # noqa: F401
-from .filter_subjects import main as filter_subjects  # noqa: F401
-from .fit_vocabulary_indices import main as fit_vocabulary_indices  # noqa: F401
-from .normalization import main as normalization  # noqa: F401
-from .occlude_outliers import main as occlude_outliers  # noqa: F401
-from .reorder_measurements import main as reorder_measurements  # noqa: F401
-from .reshard_to_split import main as reshard_to_split  # noqa: F401
+from .add_time_derived_measurements import stage as add_time_derived_measurements  # noqa: F401
+from .aggregate_code_metadata import stage as aggregate_code_metadata  # noqa: F401
+from .extract_values import stage as extract_values  # noqa: F401
+from .filter_measurements import stage as filter_measurements  # noqa: F401
+from .filter_subjects import stage as filter_subjects  # noqa: F401
+from .fit_vocabulary_indices import stage as fit_vocabulary_indices  # noqa: F401
+from .normalization import stage as normalization  # noqa: F401
+from .occlude_outliers import stage as occlude_outliers  # noqa: F401
+from .reorder_measurements import stage as reorder_measurements  # noqa: F401
+from .reshard_to_split import stage as reshard_to_split  # noqa: F401
 
 
 def get_all_stages():

--- a/src/MEDS_transforms/stages/__init__.py
+++ b/src/MEDS_transforms/stages/__init__.py
@@ -1,7 +1,7 @@
 from importlib.metadata import entry_points
 
 from .. import __package_name__
-from .base import MEDS_transforms_stage  # noqa: F401
+from .base import Stage  # noqa: F401
 from .examples import StageExample, get_nested_test_cases  # noqa: F401
 
 # Here are all the stages that are registered in the entry points, imported here so they can be imported at a

--- a/src/MEDS_transforms/stages/add_time_derived_measurements/__init__.py
+++ b/src/MEDS_transforms/stages/add_time_derived_measurements/__init__.py
@@ -1,5 +1,1 @@
-from .add_time_derived_measurements import add_time_derived_measurements as _stage
-
-main = _stage.main
-
-__all__ = ["main"]
+from .add_time_derived_measurements import add_time_derived_measurements as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/add_time_derived_measurements/add_time_derived_measurements.py
+++ b/src/MEDS_transforms/stages/add_time_derived_measurements/add_time_derived_measurements.py
@@ -7,7 +7,7 @@ import polars as pl
 from omegaconf import DictConfig, OmegaConf
 
 from ... import INFERRED_STAGE_KEYS
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -387,7 +387,7 @@ def time_of_day_fntr(cfg: DictConfig) -> Callable[[pl.DataFrame], pl.DataFrame]:
     return fn
 
 
-@MEDS_transforms_stage
+@Stage.register
 def add_time_derived_measurements(stage_cfg: DictConfig) -> Callable[[pl.LazyFrame], pl.LazyFrame]:
     """Adds all requested time-derived measurements to a DataFrame.
 

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/__init__.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/__init__.py
@@ -1,3 +1,5 @@
-from .aggregate_code_metadata import main  # noqa: F401
+from .aggregate_code_metadata import stage
+
+main = stage.main
 
 __all__ = ["main"]

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/__init__.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/__init__.py
@@ -1,5 +1,1 @@
-from .aggregate_code_metadata import stage
-
-main = stage.main
-
-__all__ = ["main"]
+from .aggregate_code_metadata import stage  # noqa: F401

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -10,7 +10,7 @@ import polars.selectors as cs
 from meds import subject_id_field
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -740,4 +740,4 @@ def reducer_fntr(
     return reducer
 
 
-main = MEDS_transforms_stage(map_fn=mapper_fntr, reduce_fn=reducer_fntr)
+stage = Stage.register(map_fn=mapper_fntr, reduce_fn=reducer_fntr)

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -1,10 +1,13 @@
 """Functions for registering and defining MEDS-transforms stages."""
 
-import functools
+from __future__ import annotations
+
 import inspect
 import logging
+import textwrap
 from collections.abc import Callable
 from enum import StrEnum
+from functools import partial, wraps
 
 from omegaconf import DictConfig
 
@@ -34,7 +37,7 @@ class StageType(StrEnum):
     @classmethod
     def from_fns(
         cls, main_fn: MAIN_FN_T | None, map_fn: ANY_COMPUTE_FN_T | None, reduce_fn: ANY_COMPUTE_FN_T | None
-    ) -> "StageType":
+    ) -> StageType:
         """Determines the stage type based on the provided functions.
 
         Args:
@@ -85,7 +88,47 @@ class StageType(StrEnum):
 
 
 class Stage:
-    """An object that wraps the stage information."""
+    """The representation of a MEDS-Transforms stage, in object form.
+
+    Largely speaking, this is just a container around the different component functions that are used to
+    execute the stage, as well as stage specific metadata like the name, docstring, and type.
+
+    When constructed through the decorator `Stage.register`, it will be set to mimic in usage the function
+    being decorated, though will still be a Stage object. This is done through the use of the `__call__`
+    operator, and ensures that things like doctests and imports of the function being decorated do not behave
+    unexpectedly. When constructed through the `Stage` constructor directly or through non-decorator usage,
+    instead, the `__call__` operator will point to the main function of the stage. This enables two styles of
+    usage; one where a map or compute function is decorated, but if the resulting function is imported or used
+    in doctests it will behave like the decorated function, and the main callable for the stage is only
+    accessible in the `main` variable of the stage object, and the second where a stage is constructed
+    manually and (typically) assigned to a `main` variable in a stage python script or equivalent.
+
+    This class is usually created through the `Stage.register` method -- either as a decorator, or as a
+    function directly called. See the examples below for more details.
+
+    Attributes:
+        stage_type: The type of stage this is. This is set automatically based on the provided functions. See
+            `StageType` for more details.
+        stage_name: The name of the stage. This is set automatically based on the provided functions or can be
+            set manually.
+        stage_docstring: The docstring of the stage. This is set automatically based on the provided functions
+            or can be set manually.
+        map_fn: The mapping function for the stage. This is set automatically based on the provided functions.
+            May be None for a `StageType.MAIN` stage.
+        reduce_fn: The reducing function for the stage. This is set automatically based on the provided
+            functions. May be None for a `StageType.MAP` or `StageType.MAIN` stage.
+        main_fn: The main function for the stage. This is set automatically based on the provided functions.
+    """
+
+    stage_type: StageType
+    stage_name: str
+
+    map_fn: ANY_COMPUTE_FN_T | None = None
+    reduce_fn: ANY_COMPUTE_FN_T | None = None
+    main_fn: MAIN_FN_T | None = None
+
+    __mimic_fn: Callable | None = None
+    __stage_docstring: str | None = None
 
     def __init__(
         self,
@@ -95,262 +138,386 @@ class Stage:
         reduce_fn: ANY_COMPUTE_FN_T | None = None,
         stage_name: str | None = None,
         stage_docstring: str | None = None,
+        mimic_fn: Callable | None = None,
     ) -> MAIN_FN_T:
         """Wraps or returns a function that can serve as the main function for a stage."""
 
-        mode = StageType.from_fns(main_fn, map_fn, reduce_fn)
+        self.stage_type = StageType.from_fns(main_fn, map_fn, reduce_fn)
 
         if stage_name is None:
             stage_name = (main_fn or map_fn).__module__.split(".")[-1]
 
-        match mode:
+        self.stage_name = stage_name
+        self.stage_docstring = stage_docstring
+
+        self.main_fn = main_fn
+        self.map_fn = map_fn
+        self.reduce_fn = reduce_fn
+        if mimic_fn is not None:
+            self.mimic_fn = mimic_fn
+
+    @property
+    def stage_docstring(self) -> str:
+        """The docstring for the stage.
+
+        This is set automatically based on the provided functions.
+        """
+        if self.__stage_docstring is not None:
+            return self.__stage_docstring
+
+        match self.stage_type:
             case StageType.MAIN:
-                stage_docstring = stage_docstring or inspect.getdoc(main_fn) or ""
-                self.__call_fn = main_fn
+                return self.main_fn_docstring
             case StageType.MAP:
-                stage_docstring = stage_docstring or inspect.getdoc(map_fn) or ""
+                return self.map_fn_docstring
+            case StageType.MAPREDUCE:
+                return f"Map Stage:\n{self.map_fn_docstring}\n\nReduce stage:\n{self.reduce_fn_docstring}"
 
-                @functools.wraps(map_fn)
+    @stage_docstring.setter
+    def stage_docstring(self, docstring: str):
+        self.__stage_docstring = docstring
+
+    @property
+    def main_fn_docstring(self) -> str:
+        return (inspect.getdoc(self.main_fn) or "") if self.main_fn is not None else ""
+
+    @property
+    def map_fn_docstring(self) -> str:
+        return (inspect.getdoc(self.map_fn) or "") if self.map_fn is not None else ""
+
+    @property
+    def reduce_fn_docstring(self) -> str:
+        return (inspect.getdoc(self.reduce_fn) or "") if self.reduce_fn is not None else ""
+
+    @property
+    def main(self) -> MAIN_FN_T:
+        match self.stage_type:
+            case StageType.MAIN:
+
+                @wraps(self.main_fn)
                 def main_fn(cfg: DictConfig):
-                    return map_stage(cfg, map_fn)
+                    return self.main_fn(cfg)
 
-                main_fn.__name__ = stage_name
-                self.__call_fn = map_fn
+            case StageType.MAP:
+
+                @wraps(self.map_fn)
+                def main_fn(cfg: DictConfig):
+                    return map_stage(cfg, self.map_fn)
 
             case StageType.MAPREDUCE:
-                stage_docstring = stage_docstring or (
-                    f"Map Stage:\n{inspect.getdoc(map_fn) or ''}\n\n"
-                    f"Reduce stage:\n{inspect.getdoc(reduce_fn) or ''}"
-                )
 
                 def main_fn(cfg: DictConfig):
-                    return mapreduce_stage(cfg, map_fn, reduce_fn)
+                    return mapreduce_stage(cfg, self.map_fn, self.reduce_fn)
 
-                main_fn.__name__ = stage_name
-                self.__call_fn = map_fn
+        main_fn.__name__ = self.stage_name
+        main_fn.__doc__ = self.stage_docstring
+        return main_fn
 
-        main_fn.__doc__ = stage_docstring
+    @property
+    def mimic_fn(self) -> Callable | None:
+        """The function that this stage object should "mimic" when treated like a plain function.
 
-        self.main = main_fn
-        self.__name__ = self.__call_fn.__name__
-        self.__doc__ = self.__call_fn.__doc__
+        When used as a decorator, we want this stage to mimic the decorated function upon normal usage. This
+        practice enables doctests and imports of the stage function to work as expected. This property gets
+        the function being mimicked.
+        """
+        return self.__mimic_fn
+
+    @mimic_fn.setter
+    def mimic_fn(self, fn: Callable):
+        """Sets the function that this stage object should "mimic" when treated like a plain function.
+
+        In addition to the function itself, this also overwrites variables like `__name__` and `__doc__` to
+        match the decorated function.
+        """
+
+        if not inspect.isfunction(fn):
+            raise TypeError(f"Cannot set mimic_fn to non-function. Got {type(fn)}")
+
+        self.__mimic_fn = fn
+        self.__name__ = fn.__name__
+        self.__doc__ = fn.__doc__
 
     def __call__(self, *args, **kwargs):
-        self.__call_fn(*args, **kwargs)
+        if self.mimic_fn is not None:
+            return self.mimic_fn(*args, **kwargs)
 
+        if len(args) == 1 and len(kwargs) == 0 and inspect.isfunction(args[0]):
+            # This is likely inappropriate decorator usage, so we raise a custom error.
+            raise ValueError(
+                "If a Stage is constructed via keyword arguments directly (including a `main_fn` or a "
+                "`map_fn`), then it cannot be used as a decorator or otherwise called directly."
+            )
 
-def MEDS_transforms_stage(*args, **kwargs):
-    """This is a decorator used to define and register a MEDS-Transforms stage of any variety.
+        raise ValueError(f"Stage {self.stage_name} has no function to mimic, so can't be called directly.")
 
-    It can be used in a variety of ways, depending on the arguments provided and the manner of invocation:
+    def __str__(self) -> str:
+        lines = [
+            f"Stage {self.stage_name}:",
+            f"  Type: {self.stage_type}",
+            "  Docstring:",
+        ]
 
-      1. If used as a decorator without arguments to a single function named `main`, it will define a
-         `StageType.MAIN` stage using that function, and the return value will be the target executable main
-         function itself (which will have an identical signature to the passed function). The function will
-         not have other methods registered to it.
-      2. If used as a decorator without arguments to a single function _not_ named `main`, it will define a
-         `StageType.MAP` stage using that function or functor as the mapper. The return value will be a new
-         function object that has the same signature as the passed function, but with a new method `main`
-         attached to it that contains the main CLI entry point for the stage and can be invoked with hydra.
-      3. If used as a decorator with keyword arguments to a single function named `main`, and the arguments do
-         not include `map_fn` or `reduce_fn`, it will define a `StageType.MAIN` stage using that function, and
-         the other keyword arguments will overwrite the defaults used in the definition of the stage.
-      4. If used as a decorator with keyword arguments to a single function _not_ named `main`, and the
-         arguments do not include `map_fn` or `reduce_fn`, it will define a `StageType.MAP` stage using that
-         function or functor as the mapper, and the other keyword arguments will overwrite the defaults used
-         in the definition of that stage.
-      5. If used as a decorator with keyword arguments to a single function regardless of the name, and the
-         keyword arguments define a `reduce_fn` but do not define a `map_fn`, then a `StageType.MAPREDUCE`
-         stage will be created and attached to the function via the `main` entry point, with the passed
-         function treated as the mapper and the `reduce_fn` as the reducer. The other keyword arguments will
-         be used as normal. The function decorated will be returned without alteration to its signature.
-      6. If used as a decorator to a single function with the `map_fn` keyword argument provided, it will
-         throw an error.
-      7. If called directly with only keyword arguments, not as a decorator to a function, with either
-         `main_fn`, `map_fn`, or both `map_fn` and `reduce_fn` defined, it will produce the associated stage
-         for those settings and return the main function directly, without modifying any passed function.
-      8. If called with multiple position arguments, it will throw an error.
+        pretty_wrap = partial(textwrap.wrap, width=110, initial_indent="    | ", subsequent_indent="    | ")
 
-    In some cases, the attached main function will have a docstring and name set based on the passed or
-    inferred stage name and stage docstring. Any non-main function returned will be unmodified in these
-    aspects.
+        docstring_lines = textwrap.dedent(self.stage_docstring).splitlines()
+        for line in docstring_lines:
+            lines.extend(pretty_wrap(line))
 
-    Args:
-        *args: Positional arguments. If used as a decorator, this should be a single function.
-        **kwargs: Keyword arguments. These can include `main_fn`, `map_fn`, `reduce_fn`,
-            `stage_name`, and `stage_docstring`. Other keyword arguments will cause an error. Not all keyword
-            arguments are required for all usages of the decorator.
-
-    Returns:
-        Callable: May be the original function passed in with a `main` method attached or a new function. See
-            the description above for details.
-
-    Raises:
-        ValueError: If multiple positional arguments are passed or if the function is not callable.
-        TypeError: If the first positional argument is not a function.
-        ValueError: If both `main_fn` and `map_fn` or `reduce_fn` are provided.
-
-    Examples:
-        >>> def main(cfg: DictConfig):
-        ...     '''base main docstring'''
-        ...     return "main"
-        >>> def map_fn(cfg: DictConfig, stage_cfg: DictConfig):
-        ...     '''base map docstring'''
-        ...     return "map"
-        >>> def reduce_fn(cfg: DictConfig, stage_cfg: DictConfig):
-        ...     '''base reduce docstring'''
-        ...     return "reduce"
-
-        When used with only keyword arguments that fully define a function, the output main function will be
-        returned, and the input functions will be unmodified.
-
-        >>> fn = MEDS_transforms_stage(main_fn=main)
-        >>> hasattr(fn, "main")
-        True
-        >>> hasattr(main, "main")
-        False
-        >>> fn.__name__
-        'main'
-        >>> fn.__doc__
-        'base main docstring'
-
-        If we do this with the map or mapreduce stage set-up, the returned function can't be executed as it
-        will try to run our actual mapreduce stages, but we show the surrounding properties:
-
-        >>> fn = MEDS_transforms_stage(map_fn=map_fn)
-        >>> hasattr(fn, "main")
-        True
-        >>> fn.__name__
-        'map_fn'
-        >>> fn.__doc__ # Inferred from the map function docstring
-        'base map docstring'
-        >>> fn = MEDS_transforms_stage(map_fn=map_fn, reduce_fn=reduce_fn)
-        >>> hasattr(fn, "main")
-        True
-        >>> fn.__name__
-        'map_fn'
-        >>> print(fn.__doc__) # Inferred from the map function docstring
-        base map docstring
-        >>> map_fn.__name__
-        'map_fn'
-        >>> map_fn.__doc__
-        'base map docstring'
-        >>> reduce_fn.__name__
-        'reduce_fn'
-        >>> reduce_fn.__doc__
-        'base reduce docstring'
-
-        If used as a decorator (equivalently, if passed a single positional argument) to a function named
-        `main`, it will define a `StageType.MAIN` stage using that.
-
-        >>> fn = MEDS_transforms_stage(main)
-        >>> hasattr(fn, "main")
-        True
-        >>> fn.__name__
-        'main'
-        >>> fn.__doc__
-        'base main docstring'
-
-        If used as a decorator (equivalently, if passed a single positional argument) to a function not named
-        `main`, it will define a map or mapreduce stage as appropriate, using the decorated function as a
-        mapper, and return the passed function with a new method `main` attached to it that contains the main
-        CLI entry point for the stage. We can't run the 'main' function here as it implements other stage
-        operations, but we can check that it has been added to the function.
-
-        >>> fn = MEDS_transforms_stage(map_fn)
-        >>> fn(cfg={}, stage_cfg={})
-        'map'
-        >>> hasattr(fn, "main")
-        True
-        >>> fn.__name__
-        'map_fn'
-        >>> fn.__doc__
-        'base map docstring'
-        >>> fn.main.__name__ # Inferred from the source module name
-        'map_fn'
-        >>> fn.main.__doc__ # Inferred from the map function docstring
-        'base map docstring'
-        >>> fn = MEDS_transforms_stage(map_fn, reduce_fn=reduce_fn)
-        >>> fn(cfg={}, stage_cfg={}) # Still the mapper -- that is the "root" function
-        'map'
-        >>> hasattr(fn, "main")
-        True
-        >>> fn.main.__name__ # Inferred from the source module name
-        'map_fn'
-        >>> print(fn.main.__doc__) # Inferred from the map function docstring
-        Map Stage:
-        base map docstring
-        <BLANKLINE>
-        Reduce stage:
-        base reduce docstring
-
-        Keyword arguments can be used to specify the config path, stage name, and docstring. These are used to
-        modify the returned stage name and docstring, and the config path is used to set up the hydra wrapper:
-
-        >>> @MEDS_transforms_stage(stage_name="bar", stage_docstring="baz")
-        ... def special_map(cfg: DictConfig):
-        ...     '''Not baz'''
-        ...     return "map"
-        >>> special_map.main.__name__
-        'bar'
-        >>> special_map.main.__doc__
-        'baz'
-
-        If specified with no positional arguments and only non-determining keyword arguments (meaning no main
-        or map function), then a decorator is returned that itself takes a function:
-
-        >>> fntr = MEDS_transforms_stage(stage_name="bar", stage_docstring="baz")
-        >>> fn = fntr(main)
-        >>> hasattr(fn, "main")
-        True
-        >>> fn = fntr(map_fn)
-        >>> fn(cfg={}, stage_cfg={})
-        'map'
-        >>> hasattr(fn, "main")
-        True
-
-        Errors are raised if the function is not callable or if multiple positional arguments are passed or if
-        both `main_fn` and `map_fn` or `reduce_fn` are provided.
-
-        >>> MEDS_transforms_stage("foo", "bar")
-        Traceback (most recent call last):
-            ...
-        ValueError: MEDS_transforms_stage can only be used with at most a single positional arg. Got 2
-        >>> MEDS_transforms_stage("foo")
-        Traceback (most recent call last):
-            ...
-        TypeError: First argument must be a function. Got <class 'str'>
-        >>> MEDS_transforms_stage(main, map_fn=map_fn)
-        Traceback (most recent call last):
-            ...
-        ValueError: Cannot provide main_fn or map_fn kwargs when using as a decorator.
-        >>> MEDS_transforms_stage(map_fn, main_fn=main)
-        Traceback (most recent call last):
-            ...
-        ValueError: Cannot provide main_fn or map_fn kwargs when using as a decorator.
-    """
-
-    def decorator(fn: Callable, **kwargs):
-        if not inspect.isfunction(fn):
-            raise TypeError(f"First argument must be a function. Got {type(fn)}")
-
-        if "main_fn" in kwargs or "map_fn" in kwargs:
-            raise ValueError("Cannot provide main_fn or map_fn kwargs when using as a decorator.")
-
-        if (fn.__name__ == "main") and ("reduce_fn" not in kwargs):
-            return Stage(main_fn=fn, **kwargs)
-
-        main_fn = Stage(main_fn=None, map_fn=fn, **kwargs)
-        fn.main = main_fn
-        return fn
-
-    if len(args) > 1:
-        raise ValueError(
-            f"MEDS_transforms_stage can only be used with at most a single positional arg. Got {len(args)}"
+        lines.extend(
+            [
+                f"  Map function: {self.map_fn.__name__ if self.map_fn else None}",
+                f"  Reduce function: {self.reduce_fn.__name__ if self.reduce_fn else None}",
+                f"  Main function: {self.main_fn.__name__ if self.main_fn else None}",
+                f"  Mimic function: {self.mimic_fn.__name__ if self.mimic_fn else None}",
+            ]
         )
-    if len(args) == 0:
-        if "main_fn" in kwargs or "map_fn" in kwargs:
-            return Stage(**kwargs)
-        return functools.partial(decorator, **kwargs)
-    else:
-        return decorator(args[0], **kwargs)
+        return "\n".join(lines)
+
+    @classmethod
+    def register(cls, *args, **kwargs) -> Callable[[Callable], Stage] | Stage:
+        """This method used to define and register a MEDS-Transforms stage of any variety.
+
+        It can be used either as a decorator, a parametrized decorator, or a direct method, depending on the
+        arguments provided and manner of invocation.
+
+        ### As a decorator
+        If used as a decorator (e.g., `@Stage.register`) on a single function, it will define a stage using
+        that function. The stage defined will either be a `StageType.MAIN` stage if the function is named
+        `main`, or a `StageType.MAP` stage otherwise. The return value will be a Stage object set to mimic the
+        called function.
+
+        ### As a parametrized decorator
+        If used as a parametrized decorator (e.g., `@Stage.register(stage_name="foo")`), it will define a
+        stage using the decorated function, but with the specified keyword arguments modifying the stage
+        appropriately. The keyword arguments included can include any property save `main_fn` or `map_fn`. The
+        stage will either be a `StageType.MAIN` stage if the function is named `main` (in which case a
+        `reduce_fn` property cannot be set), a `StageType.MAP` stage if the decorated function is not named
+        main and a `reduce_fn` is not set, or a `StageType.MAPREDUCE` stage if the decorated function is not
+        named `main` and a `reduce_fn` is set. The return value will be a Stage object set to mimic the
+        decorated function. If a `reduce_fn` is passed as a keyword argument, it will not be modified.
+
+        ### As a direct method
+        If used as a direct method, (e.g., `main = Stage.register(main_fn=main)`), it will define a stage
+        using the provided arguments, and return the stage object. The returned object will not be set to
+        mimic any function, and the `main` method will be the main entry point for the stage. This mode is
+        only activated if sufficient keyword arguments are provided to define a stage (meaning a `main_fn` or
+        `map_fn` must be set). The passed functions will not be modified.
+
+        Args:
+            *args: Positional arguments. If used as a decorator, this should be a single function, and no
+                keyword arguments should be set.
+            **kwargs: Keyword arguments. These can include `main_fn`, `map_fn`, `reduce_fn`,
+                `stage_name`, and `stage_docstring`. Other keyword arguments will cause an error. Not all
+                keyword arguments are required for all usages of the decorator.
+
+        Returns:
+            Either a `Stage` object or a decorator function, depending on the arguments provided.
+
+        Raises:
+            ValueError: If multiple positional arguments are passed or if the function is not callable.
+            TypeError: If the first positional argument is not a function.
+            ValueError: If both `main_fn` and `map_fn` or `reduce_fn` are provided.
+
+        Examples:
+
+            When used with only keyword arguments that fully define a function a stage set to mimic nothing is
+            returned directly, with the parameters set as defined by what kind of stage is being created.
+
+            >>> def main(cfg: DictConfig):
+            ...     '''base main docstring'''
+            ...     return "main"
+            >>> def map_fn(cfg: DictConfig, stage_cfg: DictConfig):
+            ...     '''base map docstring'''
+            ...     return "map"
+            >>> def reduce_fn(cfg: DictConfig, stage_cfg: DictConfig):
+            ...     '''base reduce docstring'''
+            ...     return "reduce"
+            >>> stage = Stage.register(main_fn=main)
+            >>> print(stage) # The name is inferred from the name of the file:
+            Stage base:
+              Type: main
+              Docstring:
+                | base main docstring
+              Map function: None
+              Reduce function: None
+              Main function: main
+              Mimic function: None
+
+            As it has no mimic function, if you try to call it directly, it will raise an error, and not act
+            like the main function.
+            >>> main({})
+            'main'
+            >>> stage({})
+            Traceback (most recent call last):
+                ...
+            ValueError: Stage base has no function to mimic, so can't be called directly.
+
+            >>> print(Stage.register(map_fn=map_fn))
+            Stage base:
+              Type: map
+              Docstring:
+                | base map docstring
+              Map function: map_fn
+              Reduce function: None
+              Main function: None
+              Mimic function: None
+            >>> print(Stage.register(map_fn=map_fn, reduce_fn=reduce_fn))
+            Stage base:
+              Type: mapreduce
+              Docstring:
+                | Map Stage:
+                | base map docstring
+                | Reduce stage:
+                | base reduce docstring
+              Map function: map_fn
+              Reduce function: reduce_fn
+              Main function: None
+              Mimic function: None
+
+            If you call it with main and map functions or a main and a reduce function, it will raise an
+            error:
+
+            >>> Stage.register(main_fn=main, map_fn=map_fn)
+            Traceback (most recent call last):
+                ...
+            ValueError: Only one of main_fn or map_fn/reduce_fn should be provided.
+            >>> Stage.register(main_fn=main, reduce_fn=reduce_fn)
+            Traceback (most recent call last):
+                ...
+            ValueError: Only one of main_fn or map_fn/reduce_fn should be provided.
+
+            You can also use it as a decorator:
+
+            >>> @Stage.register
+            ... def main(cfg: DictConfig):
+            ...     '''base main docstring'''
+            ...     return "main"
+
+            The output of the decorator, saved here to the variable `main`, will "mimic" the decorated
+            function under normal usage:
+
+            >>> main.__name__
+            'main'
+            >>> main.__doc__
+            'base main docstring'
+            >>> main({})
+            'main'
+
+            ... but it is actually a stage object defined by the decorator:
+
+            >>> print(main)
+            Stage base:
+              Type: main
+              Docstring:
+                | base main docstring
+              Map function: None
+              Reduce function: None
+              Main function: main
+              Mimic function: main
+
+            When used as a decorator, you can also parametrize the decorator:
+
+            >>> @Stage.register(stage_name="foo", stage_docstring="bar")
+            ... def main(cfg: DictConfig):
+            ...     '''base main docstring'''
+            ...     return "main"
+            >>> print(main)
+            Stage foo:
+              Type: main
+              Docstring:
+                | bar
+              Map function: None
+              Reduce function: None
+              Main function: main
+              Mimic function: main
+
+            The decorated function will be inferred to be a "main" function if it is named "main" and there is
+            no reduce function specified in the parametrized keyword arguments to the decorator. Otherwise, it
+            will be assumed to be a map function:
+
+            >>> @Stage.register
+            ... def map_fn(cfg: DictConfig, stage_cfg: DictConfig):
+            ...     '''base map docstring'''
+            ...     return "map"
+            >>> print(map_fn)
+            Stage base:
+              Type: map
+              Docstring:
+                | base map docstring
+              Map function: map_fn
+              Reduce function: None
+              Main function: None
+              Mimic function: map_fn
+            >>> @Stage.register(reduce_fn=reduce_fn)
+            ... def main(cfg: DictConfig):
+            ...     '''base main docstring'''
+            ...     return "main"
+            >>> print(main)
+            Stage base:
+              Type: mapreduce
+              Docstring:
+                | Map Stage:
+                | base main docstring
+                | Reduce stage:
+                | base reduce docstring
+              Map function: main
+              Reduce function: reduce_fn
+              Main function: None
+              Mimic function: main
+
+            You can't use it as a decorator while specifying either the main or map function in the keyword
+            arguments:
+
+            >>> @Stage.register(map_fn=map_fn)
+            ... def reduce_fn(cfg: DictConfig, stage_cfg: DictConfig):
+            ...     '''base reduce docstring'''
+            ...     return "reduce"
+            Traceback (most recent call last):
+                ...
+            ValueError: If a Stage is constructed via keyword arguments directly (including a `main_fn` or a
+            `map_fn`), then it cannot be used as a decorator or otherwise called directly.
+
+            You also can't specify a positional argument and keyword arguments at the same time or multiple
+            positional arguments:
+
+            >>> stage = Stage.register(main, stage_name="foo")
+            Traceback (most recent call last):
+                ...
+            ValueError: Cannot provide keyword arguments when using as a decorator.
+            >>> stage = Stage.register(main, map_fn)
+            Traceback (most recent call last):
+                ...
+            ValueError: Stage.register can only be used with at most a single positional arg. Got 2
+        """
+
+        def decorator(fn: Callable, **kwargs):
+            if not inspect.isfunction(fn):
+                raise TypeError(f"First argument must be a function. Got {type(fn)}")
+
+            if "main_fn" in kwargs or "map_fn" in kwargs:
+                raise ValueError("Cannot provide main_fn or map_fn kwargs when using as a decorator.")
+
+            stage_kwargs = {**kwargs}
+
+            if (fn.__name__ == "main") and ("reduce_fn" not in kwargs):
+                stage_kwargs["main_fn"] = fn
+            else:
+                stage_kwargs["map_fn"] = fn
+
+            stage = Stage(**stage_kwargs)
+            stage.mimic_fn = fn
+            return stage
+
+        if len(args) == 0:
+            if "main_fn" in kwargs or "map_fn" in kwargs:
+                return Stage(**kwargs)
+            return partial(decorator, **kwargs)
+        elif len(args) == 1:
+            if kwargs:
+                raise ValueError("Cannot provide keyword arguments when using as a decorator.")
+            return decorator(args[0])
+        else:
+            raise ValueError(
+                f"Stage.register can only be used with at most a single positional arg. Got {len(args)}"
+            )

--- a/src/MEDS_transforms/stages/extract_values/__init__.py
+++ b/src/MEDS_transforms/stages/extract_values/__init__.py
@@ -1,5 +1,1 @@
-from .extract_values import extract_values as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .extract_values import extract_values as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/extract_values/extract_values.py
+++ b/src/MEDS_transforms/stages/extract_values/extract_values.py
@@ -9,12 +9,12 @@ from omegaconf import DictConfig
 
 from ... import DEPRECATED_NAMES, INFERRED_STAGE_KEYS, MANDATORY_TYPES
 from ...parser import cfg_to_expr
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
 
-@MEDS_transforms_stage
+@Stage.register
 def extract_values(stage_cfg: DictConfig) -> Callable[[pl.LazyFrame], pl.LazyFrame]:
     """Create a function that extracts values from a MEDS cohort.
 

--- a/src/MEDS_transforms/stages/filter_measurements/__init__.py
+++ b/src/MEDS_transforms/stages/filter_measurements/__init__.py
@@ -1,5 +1,1 @@
-from .filter_measurements import filter_measurements as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .filter_measurements import filter_measurements as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/filter_measurements/filter_measurements.py
+++ b/src/MEDS_transforms/stages/filter_measurements/filter_measurements.py
@@ -5,10 +5,10 @@ from collections.abc import Callable
 import polars as pl
 from omegaconf import DictConfig
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 
-@MEDS_transforms_stage
+@Stage.register
 def filter_measurements(
     stage_cfg: DictConfig, code_metadata: pl.LazyFrame, code_modifiers: list[str] | None = None
 ) -> Callable[[pl.LazyFrame], pl.LazyFrame]:

--- a/src/MEDS_transforms/stages/filter_subjects/__init__.py
+++ b/src/MEDS_transforms/stages/filter_subjects/__init__.py
@@ -1,5 +1,1 @@
-from .filter_subjects import filter_subjects as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .filter_subjects import filter_subjects as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/filter_subjects/filter_subjects.py
+++ b/src/MEDS_transforms/stages/filter_subjects/filter_subjects.py
@@ -7,7 +7,7 @@ from functools import partial
 import polars as pl
 from omegaconf import DictConfig
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +197,7 @@ def filter_subjects_by_num_events(df: pl.LazyFrame, min_events_per_subject: int)
     return df.filter(pl.col("time").n_unique().over("subject_id") >= min_events_per_subject)
 
 
-@MEDS_transforms_stage
+@Stage.register
 def filter_subjects(stage_cfg: DictConfig) -> Callable[[pl.LazyFrame], pl.LazyFrame]:
     """Returns a function that filters subjects by the number of measurements and events they have.
 

--- a/src/MEDS_transforms/stages/fit_vocabulary_indices/__init__.py
+++ b/src/MEDS_transforms/stages/fit_vocabulary_indices/__init__.py
@@ -1,3 +1,1 @@
-from .fit_vocabulary_indices import main  # noqa: F401
-
-__all__ = ["main"]
+from .fit_vocabulary_indices import main as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/fit_vocabulary_indices/fit_vocabulary_indices.py
+++ b/src/MEDS_transforms/stages/fit_vocabulary_indices/fit_vocabulary_indices.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import polars as pl
 from omegaconf import DictConfig, OmegaConf
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +191,7 @@ VOCABULARY_ORDERING_METHODS: dict[VOCABULARY_ORDERING, INDEX_ASSIGNMENT_FN] = {
 }
 
 
-@MEDS_transforms_stage
+@Stage.register
 def main(cfg: DictConfig):
     """Assigns integral vocabulary IDs to codes in the metadata file, for use in tokenizing the dataset.
 

--- a/src/MEDS_transforms/stages/normalization/__init__.py
+++ b/src/MEDS_transforms/stages/normalization/__init__.py
@@ -1,5 +1,1 @@
-from .normalization import normalization as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .normalization import normalization as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/normalization/normalization.py
+++ b/src/MEDS_transforms/stages/normalization/normalization.py
@@ -2,10 +2,10 @@
 
 import polars as pl
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 
-@MEDS_transforms_stage
+@Stage.register
 def normalization(
     df: pl.LazyFrame, code_metadata: pl.DataFrame, code_modifiers: list[str] | None = None
 ) -> pl.LazyFrame:

--- a/src/MEDS_transforms/stages/occlude_outliers/__init__.py
+++ b/src/MEDS_transforms/stages/occlude_outliers/__init__.py
@@ -1,5 +1,1 @@
-from .occlude_outliers import occlude_outliers as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .occlude_outliers import occlude_outliers as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/occlude_outliers/occlude_outliers.py
+++ b/src/MEDS_transforms/stages/occlude_outliers/occlude_outliers.py
@@ -5,10 +5,10 @@ from collections.abc import Callable
 import polars as pl
 from omegaconf import DictConfig
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 
-@MEDS_transforms_stage
+@Stage.register
 def occlude_outliers(
     stage_cfg: DictConfig, code_metadata: pl.LazyFrame, code_modifiers: list[str] | None = None
 ) -> Callable[[pl.LazyFrame], pl.LazyFrame]:

--- a/src/MEDS_transforms/stages/reorder_measurements/__init__.py
+++ b/src/MEDS_transforms/stages/reorder_measurements/__init__.py
@@ -1,5 +1,1 @@
-from .reorder_measurements import reorder_measurements as _stage
-
-__all__ = ["main"]
-
-main = _stage.main
+from .reorder_measurements import reorder_measurements as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/reorder_measurements/reorder_measurements.py
+++ b/src/MEDS_transforms/stages/reorder_measurements/reorder_measurements.py
@@ -8,12 +8,12 @@ from omegaconf import DictConfig, ListConfig
 
 from MEDS_transforms.utils import get_smallest_valid_uint_type
 
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
 
-@MEDS_transforms_stage
+@Stage.register
 def reorder_measurements(
     stage_cfg: DictConfig, code_metadata: pl.DataFrame, code_modifiers: list[str] | None = None
 ) -> Callable[[pl.LazyFrame], pl.LazyFrame]:

--- a/src/MEDS_transforms/stages/reshard_to_split/__init__.py
+++ b/src/MEDS_transforms/stages/reshard_to_split/__init__.py
@@ -1,3 +1,1 @@
-from .reshard_to_split import main  # noqa: F401
-
-__all__ = ["main"]
+from .reshard_to_split import main as stage  # noqa: F401

--- a/src/MEDS_transforms/stages/reshard_to_split/reshard_to_split.py
+++ b/src/MEDS_transforms/stages/reshard_to_split/reshard_to_split.py
@@ -16,7 +16,7 @@ from omegaconf import DictConfig
 
 from ...mapreduce import rwlock_wrap, shard_iterator, shuffle_shards
 from ...utils import stage_init, write_lazyframe
-from .. import MEDS_transforms_stage
+from .. import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +260,7 @@ def write_json(d: dict, fp: Path) -> None:
     fp.write_text(json.dumps(d))
 
 
-@MEDS_transforms_stage
+@Stage.register
 def main(cfg: DictConfig):
     """Re-shard a MEDS cohort to in a manner that subdivides subject splits."""
 


### PR DESCRIPTION
This can be done in a manner that does not break other usage or doctests by having the class object "mimic" a decorated function via the `__call__` method, but will allow a much cleaner API around retrieving stages and storing stage metadata, such as example directories, default configs, etc.