### PR TITLE
Update utils.py

### DIFF
--- a/src/MEDS_transforms/utils.py
+++ b/src/MEDS_transforms/utils.py
@@ -55,7 +55,7 @@ def get_smallest_valid_uint_type(num: int | float | pl.Expr) -> pl.DataType:
 def write_lazyframe(df: pl.LazyFrame, out_fp: Path) -> None:
     if isinstance(df, pl.LazyFrame):
         df = df.collect()
-
+    out_fp.parent.mkdir(parents=True, exist_ok=True)
     df.write_parquet(out_fp, use_pyarrow=True)
 
 


### PR DESCRIPTION
Hey @mmcdermott. I was running the eICU template provided but while running the `-pytest` I encountered this problem. Was wondering if we can add this simple line in `meds_transform` in the `utils.py` which should take care of this issue. Full log from the pytest is here: 

```
E             [2025-04-02 16:29:13,909][eICU_MEDS.pre_MEDS][INFO] - Validated 24h times in 0:00:00.007987
E             [2025-04-02 16:29:13,910][eICU_MEDS.pre_MEDS][WARNING] - NOT validating the `unitVisitNumber` column as that isn't implemented yet.
E             [2025-04-02 16:29:13,910][eICU_MEDS.pre_MEDS][WARNING] - NOT SURE ABOUT THE FOLLOWING. Check with the eICU team:
E               - `apacheAdmissionDx` is not selected from the patients table as we grab it from `admissiondx`. Is this right?
E               - `admissionHeight` and `admissionWeight` are interpreted as **unit** admission height/weight, not hospital admission height/weight. Is this right?
E               - `age` is interpreted as the age at the time of the unit stay, not the hospital stay. Is this right?
E               - `What is the actual mean age for those > 89? Here we assume 90.
E               - Note that all the column names appear to be all in lowercase for the csv versions, vs. the docs
E             
E             Command stderr:
E             Error executing job with overrides: ['root_output_dir=/private/var/folders/sk/pvx3rsxs2s55ms05g75d17wn6_vgmg/T/tmpdnsfvc_n', 'do_download=True', 'do_overwrite=True', 'do_demo=True']
E             Traceback (most recent call last):
E               File "/Users/simlee/eICU_MEDS/src/eICU_MEDS/__main__.py", line 44, in main
E                 pre_MEDS_transform(
E               File "/Users/simlee/eICU_MEDS/src/eICU_MEDS/pre_MEDS.py", line 306, in main
E                 write_lazyframe(patient_df, output_dir / "patient.parquet")
E               File "/opt/anaconda3/lib/python3.12/site-packages/MEDS_transforms/utils.py", line 59, in write_lazyframe
E                 df.write_parquet(out_fp, use_pyarrow=True)
E               File "/opt/anaconda3/lib/python3.12/site-packages/polars/dataframe/frame.py", line 4008, in write_parquet
E                 pa.parquet.write_table(
E               File "/opt/anaconda3/lib/python3.12/site-packages/pyarrow/parquet/core.py", line 1869, in write_table
E                 with ParquetWriter(
E                      ^^^^^^^^^^^^^^**
E               File "/opt/anaconda3/lib/python3.12/site-packages/pyarrow/parquet/core.py", line 996, in __init__
E                 sink = self.file_handle = filesystem.open_output_stream(
E                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               File "pyarrow/_fs.pyx", line 881, in pyarrow._fs.FileSystem.open_output_stream
E               File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
E               File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
E             FileNotFoundError: [Errno 2] Failed to open local file '/private/var/folders/sk/pvx3rsxs2s55ms05g75d17wn6_vgmg/T/tmpdnsfvc_n/pre_MEDS/patient.parquet'. Detail: [errno 2] No such file or directory
E             
E             Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
E             
E           assert 1 == 0
E            +  where 1 = CompletedProcess(args='MEDS_extract-eICU root_output_dir=/private/var/folders/sk/pvx3rsxs2s55ms05g75d17wn6_vgmg/T/tmpd... [errno 2] No such file or directory\n\nSet the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.\n').returncode
``` 