### PR TITLE
Fix coverage reporting from 68% to 98%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,13 +80,16 @@ markers = [
   "parallelized: mark test as parallelized, requiring hydra-joblib-launcher",
 ]
 
+[tool.coverage.run]
+source = ["src"]
+
 [tool.coverage.report]
 exclude_also = [
     "logger\\.debug",
     "except ImportError:",
     "if TYPE_CHECKING:",
 ]
-omit = ["example/*"]
+omit = ["example/*", "src/MEDS_transforms/__init__.py"]
 
 [project.entry-points.pytest11]
 MEDS_transforms = "MEDS_transforms.pytest_plugin"

--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -33,7 +33,7 @@ def print_help_stage():
         print(f"  - {name}")
 
 
-def run_stage():
+def run_stage():  # pragma: no cover
     """Run a stage based on command line arguments."""
 
     if len(sys.argv) < 2:

--- a/src/MEDS_transforms/pytest_plugin.py
+++ b/src/MEDS_transforms/pytest_plugin.py
@@ -12,20 +12,25 @@ Pytest Plugin Capabilities:
       may be logged by MEDS testing helpers upon partial initialization of dataset examples.
 """
 
+from __future__ import annotations
+
 import logging
 import subprocess
 import tempfile
 import tomllib
-from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from omegaconf import OmegaConf
 
 from . import __package_name__
-from .configs.stage import StageConfig
-from .stages import StageExample, get_all_registered_stages
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .stages.examples import StageExample
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +151,8 @@ def pytest_configure(config: pytest.Config):
     Now, if we call the function with the fake config and stages, we should get the expected output. This
     simulates reading the command line options and setting up the config object.
 
-        >>> with patch("MEDS_transforms.pytest_plugin.get_all_registered_stages", return_value=mock_stages):
+        >>> _P = "MEDS_transforms.stages.discovery.get_all_registered_stages"
+        >>> with patch(_P, return_value=mock_stages):
         ...     pytest_configure(config)
         >>> list(config.allowed_stages.keys())
         ['stage_1_1', 'stage_2_1']
@@ -157,7 +163,7 @@ def pytest_configure(config: pytest.Config):
 
         >>> CLI_options["test_stages_for_package"] = ["package1"]
         >>> CLI_options["test_stage"] = []
-        >>> with patch("MEDS_transforms.pytest_plugin.get_all_registered_stages", return_value=mock_stages):
+        >>> with patch(_P, return_value=mock_stages):
         ...     pytest_configure(config)
         >>> list(config.allowed_stages.keys())
         ['stage_1_1', 'stage_1_2']
@@ -167,7 +173,7 @@ def pytest_configure(config: pytest.Config):
     What if we request a stage not in the package?
 
         >>> CLI_options["test_stage"] = ["stage_1_1", "stage_2_1", "invalid_stage"]
-        >>> with patch("MEDS_transforms.pytest_plugin.get_all_registered_stages", return_value=mock_stages):
+        >>> with patch(_P, return_value=mock_stages):
         ...     pytest_configure(config)
         Traceback (most recent call last):
             ...
@@ -178,7 +184,7 @@ def pytest_configure(config: pytest.Config):
 
         >>> CLI_options["test_stages_for_package"] = []
         >>> CLI_options["test_stage"] = []
-        >>> with patch("MEDS_transforms.pytest_plugin.get_all_registered_stages", return_value=mock_stages):
+        >>> with patch(_P, return_value=mock_stages):
         ...     with patch("MEDS_transforms.pytest_plugin._auto_detect_package", return_value=None):
         ...         pytest_configure(config)
         >>> list(config.allowed_stages.keys())
@@ -197,6 +203,8 @@ def pytest_configure(config: pytest.Config):
         packages_to_test = []
 
     stages = config.getoption("test_stage")
+
+    from .stages.discovery import get_all_registered_stages
 
     registered_stages = get_all_registered_stages()
 
@@ -398,6 +406,9 @@ def pipeline_tester(
             ...
         AssertionError: Pipeline failed to produce expected output for stage 'filter_subjects'
     """
+
+    from .configs.stage import StageConfig
+    from .stages.discovery import get_all_registered_stages
 
     pipeline_stages = [StageConfig.from_arg(s).name for s in OmegaConf.create(pipeline_yaml).stages]
 

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -275,7 +275,7 @@ def run_stage(
         )
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:  # pragma: no cover
     """Run an entire pipeline based on command line arguments."""
 
     parser = argparse.ArgumentParser(description="MEDS-Transforms Pipeline Runner")

--- a/src/MEDS_transforms/stages/reshard_to_split/reshard_to_split.py
+++ b/src/MEDS_transforms/stages/reshard_to_split/reshard_to_split.py
@@ -262,7 +262,7 @@ def write_json(d: dict, fp: Path) -> None:
 
 
 @Stage.register(is_metadata=False)
-def main(cfg: DictConfig):
+def main(cfg: DictConfig):  # pragma: no cover
     """Re-shard a MEDS cohort to in a manner that subdivides subject splits."""
 
     output_dir = Path(cfg.stage_cfg.output_dir)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,23 @@
 import re
 import subprocess
+from unittest.mock import patch
 
 SCRIPT_TEMPLATE = "MEDS_transform-stage {pipeline} {stage_name}"
+
+
+def test_print_help_stage(capsys):
+    from MEDS_transforms.__main__ import print_help_stage
+
+    with patch(
+        "MEDS_transforms.__main__.get_all_registered_stages",
+        return_value={"bar_stage": None, "foo_stage": None},
+    ):
+        print_help_stage()
+
+    captured = capsys.readouterr()
+    assert "Available stages:" in captured.out
+    assert "  - bar_stage" in captured.out
+    assert "  - foo_stage" in captured.out
 
 
 def test_stage_entry_point_help():


### PR DESCRIPTION
## Summary
- **Lazy imports in pytest plugin**: `pytest_plugin.py` was importing the entire package before `pytest-cov` started tracking (since it's loaded as a `pytest11` entry point). Moved `StageConfig` and `get_all_registered_stages` to function-body imports, and `StageExample` under `TYPE_CHECKING`.
- **Coverage config**: Added `[tool.coverage.run]` with `source = ["src"]` and excluded `__init__.py` (always pre-imported by plugin).
- **Subprocess entry points**: Added `# pragma: no cover` to `runner.main()`, `__main__.run_stage()`, and `reshard_to_split.main()` — these only execute via subprocess and can't be tracked by in-process coverage.
- **New test**: Added `test_print_help_stage` in `test_main.py` to cover `print_help_stage()` in-process (since `__main__.py` is skipped by pytest's doctest collector).

## Test plan
- [x] All 128 tests pass locally with Python 3.12
- [x] Coverage improved from 68% → 98%
- [x] Ruff checks pass
- [ ] CI passes on both Python 3.11 and 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)