### PR TITLE
Remove redundant parquet writes in write_for_test

### DIFF
--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -986,6 +986,14 @@ class StageExample:
             metadata_fp = metadata_dir / "codes.parquet"
             got_metadata = pl.read_parquet(metadata_fp)
             try:
+                # Align column order before comparison since parquet writers (PyArrow vs Polars)
+                # may produce different column orderings for the same data.
+                shared_cols = [c for c in self.want_metadata.columns if c in got_metadata.columns]
+                want_only = set(self.want_metadata.columns) - set(shared_cols)
+                got_only = set(got_metadata.columns) - set(shared_cols)
+                if want_only or got_only:
+                    raise AssertionError(f"Column mismatch: want-only={want_only}, got-only={got_only}")
+                got_metadata = got_metadata.select(self.want_metadata.columns)
                 assert_frame_equal(
                     self.want_metadata, got_metadata, check_row_order=False, **self.df_check_kwargs
                 )

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -923,14 +923,8 @@ class StageExample:
         if self.in_data is None:
             in_data = MEDSDataset.from_yaml(SIMPLE_STATIC_SHARDED_BY_SPLIT)
             in_data.write(input_dir)
-            return
         else:
             self.in_data.write(input_dir)
-            self.in_data._pl_code_metadata.write_parquet(input_dir / code_metadata_filepath)
-            for k, v in self.in_data._pl_shards.items():
-                fp = input_dir / "data" / f"{k}.parquet"
-                fp.parent.mkdir(parents=True, exist_ok=True)
-                v.write_parquet(fp)
 
     def __data_files(self, data_dir: Path) -> list[Path]:
         return list((data_dir).rglob("*.parquet"))


### PR DESCRIPTION
MEDSDataset.write() already writes all data shards, code metadata, and dataset metadata. The additional manual writes of _pl_code_metadata and _pl_shards were duplicating this work, introduced during the refactor in 6e75978d.