### PR TITLE
Fix mapreduce reducer race condition (closes #373)

### DIFF
--- a/src/MEDS_transforms/dataframe/write_fn.py
+++ b/src/MEDS_transforms/dataframe/write_fn.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -9,8 +10,20 @@ WRITE_FN_T = Callable[[DF_T, Path], None]
 
 
 def write_df(df: DF_T, out_fp: Path) -> None:
-    """A generic helper to write a dataframe, either lazy or eager, to a parquet file."""
+    """Atomically write a dataframe, either lazy or eager, to a parquet file.
+
+    Content is staged at ``<out_fp>.tmp`` and then ``os.replace``\\d onto
+    ``out_fp`` so concurrent readers never observe a partial parquet file at
+    the final path. The rename is atomic on POSIX and Windows as long as
+    ``out_fp`` and its staging path share a filesystem.
+    """
     if isinstance(df, pl.LazyFrame):
         df = df.collect()
     out_fp.parent.mkdir(parents=True, exist_ok=True)
-    df.write_parquet(out_fp, use_pyarrow=True)
+    tmp_fp = out_fp.with_suffix(out_fp.suffix + ".tmp")
+    try:
+        df.write_parquet(tmp_fp, use_pyarrow=True)
+        os.replace(tmp_fp, out_fp)
+    except BaseException:
+        tmp_fp.unlink(missing_ok=True)
+        raise

--- a/src/MEDS_transforms/dataframe/write_fn.py
+++ b/src/MEDS_transforms/dataframe/write_fn.py
@@ -12,8 +12,8 @@ WRITE_FN_T = Callable[[DF_T, Path], None]
 def write_df(df: DF_T, out_fp: Path) -> None:
     """Atomically write a dataframe, either lazy or eager, to a parquet file.
 
-    Content is staged at ``<out_fp>.tmp`` and then ``os.replace``\\d onto
-    ``out_fp`` so concurrent readers never observe a partial parquet file at
+    Content is staged at ``<out_fp>.tmp`` and then moved into place with
+    ``os.replace`` so concurrent readers never observe a partial parquet file at
     the final path. The rename is atomic on POSIX and Windows as long as
     ``out_fp`` and its staging path share a filesystem.
     """

--- a/src/MEDS_transforms/mapreduce/reducer.py
+++ b/src/MEDS_transforms/mapreduce/reducer.py
@@ -217,33 +217,39 @@ def reduce_over(
             "otherwise legitimately slow mappers will trigger a TimeoutError on the first recheck."
         )
 
-    deadline = time.monotonic() + max_poll_time if max_poll_time is not None else None
-    ready_fps: set[Path] = set()
+    deadline = None if max_poll_time is None else time.monotonic() + max_poll_time
+    ready: set[Path] = set()
+
+    def _is_ready(fp: Path) -> bool:
+        # ``is_file`` is a cheap stat; only if it passes do we open the parquet to check completeness.
+        return fp.is_file() and default_file_checker(fp)
+
     while True:
-        not_ready: list[Path] = []
-        for fp in in_fps:
-            if fp in ready_fps:
-                continue
-            # Fast path: skip the parquet completeness check when the file isn't even on disk yet.
-            if not fp.is_file() or not default_file_checker(fp):
-                not_ready.append(fp)
-                continue
-            ready_fps.add(fp)
-        if not not_ready:
+        ready.update(fp for fp in in_fps if fp not in ready and _is_ready(fp))
+        if len(ready) == len(in_fps):
             break
-        if deadline is not None and time.monotonic() >= deadline:
-            stuck = [fp for fp in not_ready if fp.exists()]
-            missing = [fp for fp in not_ready if not fp.exists()]
-            parts = []
-            if stuck:
-                parts.append(f"present but unreadable: {', '.join(str(fp) for fp in stuck)}")
-            if missing:
-                parts.append(f"missing: {', '.join(str(fp) for fp in missing)}")
-            raise TimeoutError(
-                f"Timed out after {max_poll_time}s waiting for reduction inputs — " + "; ".join(parts)
-            )
+
+        if deadline is None:
+            sleep_for = polling_time
+        else:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pending = [fp for fp in in_fps if fp not in ready]
+                stuck = [fp for fp in pending if fp.exists()]
+                missing = [fp for fp in pending if not fp.exists()]
+                parts = []
+                if stuck:
+                    parts.append(f"present but unreadable: {', '.join(str(fp) for fp in stuck)}")
+                if missing:
+                    parts.append(f"missing: {', '.join(str(fp) for fp in missing)}")
+                raise TimeoutError(
+                    f"Timed out after {max_poll_time}s waiting for reduction inputs — " + "; ".join(parts)
+                )
+            # Don't oversleep past the deadline; if remaining < polling_time, wake up sooner.
+            sleep_for = min(polling_time, remaining)
+
         logger.info("Waiting to begin reduction for all files to be written...")
-        time.sleep(polling_time)
+        time.sleep(sleep_for)
 
     reduced = reduce_fn(*[read_fn(fp) for fp in in_fps])
 

--- a/src/MEDS_transforms/mapreduce/reducer.py
+++ b/src/MEDS_transforms/mapreduce/reducer.py
@@ -29,7 +29,7 @@ def reduce_over(
     merge_fn: REDUCE_FN_T | None = None,
     do_overwrite: bool = False,
     polling_time: float = 0.1,
-    max_poll_time: float = 300.0,
+    max_poll_time: float | None = None,
 ):
     """Performs a reduction operation on a list of input file paths, with optional merging to existing data.
 
@@ -37,9 +37,11 @@ def reduce_over(
         in_fps: List of input file paths containing data over which the reduction should be performed.
         out_fp: Output file path where the reduced data will be saved.
         polling_time: Time in seconds to wait between checks for file readiness.
-        max_poll_time: Maximum total time in seconds to wait for input files to become readable. Raises
-            ``TimeoutError`` if any input file exists but stays invalid past this deadline — guards
-            against hangs when a mapper is permanently stuck or produced a corrupt file.
+        max_poll_time: Optional maximum total seconds to wait for input files to become readable.
+            Defaults to ``None`` (wait indefinitely). When set, ``TimeoutError`` is raised if any
+            input file exists but stays invalid past the deadline — guards against hangs when a
+            mapper is permanently stuck or produced a corrupt file. Callers should pick a value
+            meaningfully larger than ``polling_time``.
         read_fn: Function to read data from the input file paths.
         write_fn: Function to write the reduced data to the output file path.
         reduce_fn: Function to perform the reduction operation on the data. It should take two dataframe
@@ -50,7 +52,7 @@ def reduce_over(
 
     Raises:
         FileExistsError: If the output file already exists.
-        TimeoutError: If input files remain unreadable after ``max_poll_time`` seconds.
+        TimeoutError: If input files remain unreadable after ``max_poll_time`` seconds (only when set).
 
     Examples:
         >>> def reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
@@ -209,16 +211,29 @@ def reduce_over(
     if out_fp.is_file() and not do_overwrite:
         raise FileExistsError(f"Output file already exists: {out_fp.resolve()!s}")
 
-    deadline = time.monotonic() + max_poll_time
+    if max_poll_time is not None and max_poll_time <= polling_time:
+        raise ValueError(
+            f"max_poll_time ({max_poll_time}s) must be greater than polling_time ({polling_time}s); "
+            "otherwise legitimately slow mappers will trigger a TimeoutError on the first recheck."
+        )
+
+    deadline = time.monotonic() + max_poll_time if max_poll_time is not None else None
+    ready_fps: set[Path] = set()
     while True:
-        ready = [default_file_checker(fp) for fp in in_fps]
-        if all(ready):
+        not_ready: list[Path] = []
+        for fp in in_fps:
+            if fp in ready_fps:
+                continue
+            # Fast path: skip the parquet completeness check when the file isn't even on disk yet.
+            if not fp.is_file() or not default_file_checker(fp):
+                not_ready.append(fp)
+                continue
+            ready_fps.add(fp)
+        if not not_ready:
             break
-        if time.monotonic() >= deadline:
-            stuck = [fp for fp, is_ready in zip(in_fps, ready, strict=True) if not is_ready and fp.exists()]
-            missing = [
-                fp for fp, is_ready in zip(in_fps, ready, strict=True) if not is_ready and not fp.exists()
-            ]
+        if deadline is not None and time.monotonic() >= deadline:
+            stuck = [fp for fp in not_ready if fp.exists()]
+            missing = [fp for fp in not_ready if not fp.exists()]
             parts = []
             if stuck:
                 parts.append(f"present but unreadable: {', '.join(str(fp) for fp in stuck)}")

--- a/src/MEDS_transforms/mapreduce/reducer.py
+++ b/src/MEDS_transforms/mapreduce/reducer.py
@@ -29,6 +29,7 @@ def reduce_over(
     merge_fn: REDUCE_FN_T | None = None,
     do_overwrite: bool = False,
     polling_time: float = 0.1,
+    max_poll_time: float = 300.0,
 ):
     """Performs a reduction operation on a list of input file paths, with optional merging to existing data.
 
@@ -36,6 +37,9 @@ def reduce_over(
         in_fps: List of input file paths containing data over which the reduction should be performed.
         out_fp: Output file path where the reduced data will be saved.
         polling_time: Time in seconds to wait between checks for file readiness.
+        max_poll_time: Maximum total time in seconds to wait for input files to become readable. Raises
+            ``TimeoutError`` if any input file exists but stays invalid past this deadline — guards
+            against hangs when a mapper is permanently stuck or produced a corrupt file.
         read_fn: Function to read data from the input file paths.
         write_fn: Function to write the reduced data to the output file path.
         reduce_fn: Function to perform the reduction operation on the data. It should take two dataframe
@@ -46,6 +50,7 @@ def reduce_over(
 
     Raises:
         FileExistsError: If the output file already exists.
+        TimeoutError: If input files remain unreadable after ``max_poll_time`` seconds.
 
     Examples:
         >>> def reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
@@ -204,7 +209,24 @@ def reduce_over(
     if out_fp.is_file() and not do_overwrite:
         raise FileExistsError(f"Output file already exists: {out_fp.resolve()!s}")
 
-    while not all(default_file_checker(fp) for fp in in_fps):
+    deadline = time.monotonic() + max_poll_time
+    while True:
+        ready = [default_file_checker(fp) for fp in in_fps]
+        if all(ready):
+            break
+        if time.monotonic() >= deadline:
+            stuck = [fp for fp, is_ready in zip(in_fps, ready, strict=True) if not is_ready and fp.exists()]
+            missing = [
+                fp for fp, is_ready in zip(in_fps, ready, strict=True) if not is_ready and not fp.exists()
+            ]
+            parts = []
+            if stuck:
+                parts.append(f"present but unreadable: {', '.join(str(fp) for fp in stuck)}")
+            if missing:
+                parts.append(f"missing: {', '.join(str(fp) for fp in missing)}")
+            raise TimeoutError(
+                f"Timed out after {max_poll_time}s waiting for reduction inputs — " + "; ".join(parts)
+            )
         logger.info("Waiting to begin reduction for all files to be written...")
         time.sleep(polling_time)
 

--- a/src/MEDS_transforms/mapreduce/reducer.py
+++ b/src/MEDS_transforms/mapreduce/reducer.py
@@ -8,6 +8,7 @@ from typing import Protocol
 import polars as pl
 
 from ..dataframe import DF_T, READ_FN_T, WRITE_FN_T
+from .rwlock import default_file_checker
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +204,7 @@ def reduce_over(
     if out_fp.is_file() and not do_overwrite:
         raise FileExistsError(f"Output file already exists: {out_fp.resolve()!s}")
 
-    while not all(fp.is_file() for fp in in_fps):
+    while not all(default_file_checker(fp) for fp in in_fps):
         logger.info("Waiting to begin reduction for all files to be written...")
         time.sleep(polling_time)
 

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -15,19 +15,32 @@ from pathlib import Path
 
 import polars as pl
 
+from MEDS_transforms.dataframe import read_df, write_df
 from MEDS_transforms.mapreduce.reducer import reduce_over
 
+# Window during which the reducer must observe the empty-but-existing parquet
+# file, after which the writer finishes and the race would no longer reproduce.
+_RACE_WINDOW_SECONDS = 0.3
 
-def _slow_mapper_write(df: pl.DataFrame, fp: Path, pre_write_delay: float) -> None:
-    """Simulate a mapper whose parquet write is not atomic: create the file,
-    hold for `pre_write_delay` seconds, then actually write the content.
 
-    This models the real behavior of `df.write_parquet(fp)` where the file exists
-    on disk before the parquet footer is flushed.
+def _publish_before_complete_write(
+    df: pl.DataFrame,
+    fp: Path,
+    touched: threading.Event,
+    race_window: float,
+) -> None:
+    """Simulate a publish-before-complete-write interleaving.
+
+    Creates ``fp`` (so ``is_file()`` returns True), signals ``touched``, then
+    holds ``race_window`` seconds before writing real parquet content. This is
+    a synthetic interleaving, not a literal model of ``df.write_parquet``, but
+    it exposes the same contract violation: the reducer treats file existence
+    as publication.
     """
     fp.touch()
-    time.sleep(pre_write_delay)
-    df.write_parquet(fp)
+    touched.set()
+    time.sleep(race_window)
+    write_df(df, fp)
 
 
 def _reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
@@ -38,7 +51,7 @@ def test_reduce_over_waits_for_complete_parquet() -> None:
     """Reducer should wait for valid parquet, not just file existence.
 
     Currently fails with ``polars.exceptions.ComputeError`` because ``reduce_over``
-    polls ``fp.is_file()`` and reads the mapper's partial parquet file.
+    polls ``fp.is_file()`` and reads the partial parquet file.
     """
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
@@ -48,22 +61,28 @@ def test_reduce_over_waits_for_complete_parquet() -> None:
         df0 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
         df1 = pl.DataFrame({"a": [5, 6], "b": [7, 8]})
 
-        df0.write_parquet(in_fps[0])
-        slow_writer = threading.Thread(target=_slow_mapper_write, args=(df1, in_fps[1], 0.3))
+        write_df(df0, in_fps[0])
+
+        touched = threading.Event()
+        slow_writer = threading.Thread(
+            target=_publish_before_complete_write,
+            args=(df1, in_fps[1], touched, _RACE_WINDOW_SECONDS),
+        )
         slow_writer.start()
         try:
-            time.sleep(0.02)  # let the touch() land
+            # Explicit handshake: proceed only once the partial file exists.
+            assert touched.wait(timeout=5.0), "writer thread never created the partial file"
             reduce_over(
                 in_fps=in_fps,
                 out_fp=out_fp,
-                read_fn=pl.read_parquet,
-                write_fn=pl.DataFrame.write_parquet,
+                read_fn=read_df,
+                write_fn=write_df,
                 reduce_fn=_reduce_fn,
                 polling_time=0.005,
             )
         finally:
             slow_writer.join()
 
-        result = pl.read_parquet(out_fp).sort("a")
+        result = read_df(out_fp).sort("a")
         expected = pl.concat([df0, df1], how="vertical").sort("a")
         assert result.equals(expected), f"Reducer output differs:\n{result}\nvs expected:\n{expected}"

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -96,7 +96,7 @@ def test_reduce_over_times_out_on_permanently_invalid_input(tmp_path: Path) -> N
     write_df(pl.DataFrame({"a": [1]}), in_fps[0])
     in_fps[1].touch()  # exists but invalid parquet, never fixed
 
-    with pytest.raises(TimeoutError, match="Timed out"):
+    with pytest.raises(TimeoutError, match=r"present but unreadable.*broken\.parquet") as excinfo:
         reduce_over(
             in_fps=in_fps,
             out_fp=out_fp,
@@ -106,6 +106,30 @@ def test_reduce_over_times_out_on_permanently_invalid_input(tmp_path: Path) -> N
             polling_time=0.01,
             max_poll_time=0.3,
         )
+    # The "missing" branch should NOT fire here — the file exists (just isn't valid parquet).
+    assert "missing:" not in str(excinfo.value)
+
+
+def test_reduce_over_times_out_on_missing_input(tmp_path: Path) -> None:
+    """An input path that never appears should time out with a ``missing:`` message."""
+    in_fps = [tmp_path / "ok.parquet", tmp_path / "never_created.parquet"]
+    out_fp = tmp_path / "out.parquet"
+
+    write_df(pl.DataFrame({"a": [1]}), in_fps[0])
+    # Deliberately do not create in_fps[1].
+
+    with pytest.raises(TimeoutError, match=r"missing:.*never_created\.parquet") as excinfo:
+        reduce_over(
+            in_fps=in_fps,
+            out_fp=out_fp,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=_reduce_fn,
+            polling_time=0.01,
+            max_poll_time=0.3,
+        )
+    # The "present but unreadable" branch should NOT fire here — the file never existed.
+    assert "present but unreadable" not in str(excinfo.value)
 
 
 def test_reduce_over_rejects_max_poll_time_not_larger_than_polling_time(tmp_path: Path) -> None:

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -44,7 +44,7 @@ def _publish_before_complete_write(
     write_df(df, fp)
 
 
-def _reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
+def _reduce_fn(*dfs: pl.LazyFrame | pl.DataFrame) -> pl.LazyFrame | pl.DataFrame:
     return pl.concat(dfs, how="vertical")
 
 

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -14,7 +14,6 @@ import time
 from pathlib import Path
 
 import polars as pl
-import pytest
 
 from MEDS_transforms.mapreduce.reducer import reduce_over
 
@@ -35,16 +34,12 @@ def _reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
     return pl.concat(dfs, how="vertical")
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Reducer race condition: `reduce_over` treats `fp.is_file()` as 'ready', "
-        "but the mapper's parquet write is non-atomic. See issue #373."
-    ),
-    strict=True,
-    raises=pl.exceptions.ComputeError,
-)
-def test_reduce_over_races_partial_parquet_write() -> None:
-    """Reducer should wait for valid parquet, not just file existence."""
+def test_reduce_over_waits_for_complete_parquet() -> None:
+    """Reducer should wait for valid parquet, not just file existence.
+
+    Currently fails with ``polars.exceptions.ComputeError`` because ``reduce_over``
+    polls ``fp.is_file()`` and reads the mapper's partial parquet file.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
         in_fps = [tmp / f"in_{i}.parquet" for i in range(2)]
@@ -68,3 +63,7 @@ def test_reduce_over_races_partial_parquet_write() -> None:
             )
         finally:
             slow_writer.join()
+
+        result = pl.read_parquet(out_fp).sort("a")
+        expected = pl.concat([df0, df1], how="vertical").sort("a")
+        assert result.equals(expected), f"Reducer output differs:\n{result}\nvs expected:\n{expected}"

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -1,0 +1,70 @@
+"""Regression test for https://github.com/mmcdermott/MEDS_transforms/issues/373.
+
+`reduce_over` polls for input readiness with `fp.is_file()`, which returns True
+as soon as the mapper creates the output file — well before `df.write_parquet(...)`
+has flushed a valid parquet footer. The reducer then reads a partial file and
+raises `polars.exceptions.ComputeError: parquet: File out of specification`.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from MEDS_transforms.mapreduce.reducer import reduce_over
+
+
+def _slow_mapper_write(df: pl.DataFrame, fp: Path, pre_write_delay: float) -> None:
+    """Simulate a mapper whose parquet write is not atomic: create the file,
+    hold for `pre_write_delay` seconds, then actually write the content.
+
+    This models the real behavior of `df.write_parquet(fp)` where the file exists
+    on disk before the parquet footer is flushed.
+    """
+    fp.touch()
+    time.sleep(pre_write_delay)
+    df.write_parquet(fp)
+
+
+def _reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
+    return pl.concat(dfs, how="vertical")
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Reducer race condition: `reduce_over` treats `fp.is_file()` as 'ready', "
+        "but the mapper's parquet write is non-atomic. See issue #373."
+    ),
+    strict=True,
+    raises=pl.exceptions.ComputeError,
+)
+def test_reduce_over_races_partial_parquet_write() -> None:
+    """Reducer should wait for valid parquet, not just file existence."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        in_fps = [tmp / f"in_{i}.parquet" for i in range(2)]
+        out_fp = tmp / "out.parquet"
+
+        df0 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+        df1 = pl.DataFrame({"a": [5, 6], "b": [7, 8]})
+
+        df0.write_parquet(in_fps[0])
+        slow_writer = threading.Thread(target=_slow_mapper_write, args=(df1, in_fps[1], 0.3))
+        slow_writer.start()
+        try:
+            time.sleep(0.02)  # let the touch() land
+            reduce_over(
+                in_fps=in_fps,
+                out_fp=out_fp,
+                read_fn=pl.read_parquet,
+                write_fn=pl.DataFrame.write_parquet,
+                reduce_fn=_reduce_fn,
+                polling_time=0.005,
+            )
+        finally:
+            slow_writer.join()

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -14,6 +14,7 @@ import time
 from pathlib import Path
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 from MEDS_transforms.dataframe import read_df, write_df
 from MEDS_transforms.mapreduce.reducer import reduce_over
@@ -83,6 +84,7 @@ def test_reduce_over_waits_for_complete_parquet() -> None:
         finally:
             slow_writer.join()
 
-        result = read_df(out_fp).sort("a")
+        # ``read_df`` returns a LazyFrame; collect before comparing.
+        result = read_df(out_fp).collect().sort("a")
         expected = pl.concat([df0, df1], how="vertical").sort("a")
-        assert result.equals(expected), f"Reducer output differs:\n{result}\nvs expected:\n{expected}"
+        assert_frame_equal(result, expected)

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -88,3 +88,27 @@ def test_reduce_over_waits_for_complete_parquet() -> None:
         result = read_df(out_fp).collect().sort("a")
         expected = pl.concat([df0, df1], how="vertical").sort("a")
         assert_frame_equal(result, expected)
+
+
+def test_reduce_over_times_out_on_permanently_invalid_input() -> None:
+    """A permanently invalid (empty) parquet should time out, not hang forever."""
+    import pytest
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        in_fps = [tmp / "ok.parquet", tmp / "broken.parquet"]
+        out_fp = tmp / "out.parquet"
+
+        write_df(pl.DataFrame({"a": [1]}), in_fps[0])
+        in_fps[1].touch()  # exists but invalid parquet, never fixed
+
+        with pytest.raises(TimeoutError, match="Timed out"):
+            reduce_over(
+                in_fps=in_fps,
+                out_fp=out_fp,
+                read_fn=read_df,
+                write_fn=write_df,
+                reduce_fn=_reduce_fn,
+                polling_time=0.01,
+                max_poll_time=0.3,
+            )

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -1,26 +1,30 @@
 """Regression test for https://github.com/mmcdermott/MEDS_transforms/issues/373.
 
-`reduce_over` polls for input readiness with `fp.is_file()`, which returns True
-as soon as the mapper creates the output file — well before `df.write_parquet(...)`
-has flushed a valid parquet footer. The reducer then reads a partial file and
-raises `polars.exceptions.ComputeError: parquet: File out of specification`.
+``reduce_over`` used to poll for input readiness with ``fp.is_file()``, which returns True as soon
+as the mapper creates the output file — well before ``df.write_parquet(...)`` has flushed a valid
+parquet footer. The reducer then read a partial file and raised ``polars.exceptions.ComputeError:
+parquet: File out of specification``. These tests lock in the fix (atomic ``write_df`` publish plus
+a completeness-aware readiness poll).
 """
 
 from __future__ import annotations
 
-import tempfile
 import threading
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 
 from MEDS_transforms.dataframe import read_df, write_df
 from MEDS_transforms.mapreduce.reducer import reduce_over
 
-# Window during which the reducer must observe the empty-but-existing parquet
-# file, after which the writer finishes and the race would no longer reproduce.
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Window during which the reducer must observe the empty-but-existing parquet file. On a machine
+# where this isn't enough, the whole test suite is already in trouble.
 _RACE_WINDOW_SECONDS = 0.3
 
 
@@ -32,11 +36,10 @@ def _publish_before_complete_write(
 ) -> None:
     """Simulate a publish-before-complete-write interleaving.
 
-    Creates ``fp`` (so ``is_file()`` returns True), signals ``touched``, then
-    holds ``race_window`` seconds before writing real parquet content. This is
-    a synthetic interleaving, not a literal model of ``df.write_parquet``, but
-    it exposes the same contract violation: the reducer treats file existence
-    as publication.
+    Creates ``fp`` (so ``is_file()`` returns True), signals ``touched``, then holds
+    ``race_window`` seconds before writing real parquet content. This is a synthetic interleaving,
+    not a literal model of ``df.write_parquet``, but it exposes the same contract violation: the
+    reducer treats file existence as publication.
     """
     fp.touch()
     touched.set()
@@ -44,92 +47,79 @@ def _publish_before_complete_write(
     write_df(df, fp)
 
 
-def _reduce_fn(*dfs: pl.DataFrame) -> pl.DataFrame:
+def _reduce_fn(*dfs: pl.LazyFrame | pl.DataFrame) -> pl.LazyFrame | pl.DataFrame:
     return pl.concat(dfs, how="vertical")
 
 
-def test_reduce_over_waits_for_complete_parquet() -> None:
-    """Reducer should wait for valid parquet, not just file existence.
+def test_reduce_over_waits_for_complete_parquet(tmp_path: Path) -> None:
+    """Reducer should wait for valid parquet, not just file existence."""
+    in_fps = [tmp_path / f"in_{i}.parquet" for i in range(2)]
+    out_fp = tmp_path / "out.parquet"
 
-    Currently fails with ``polars.exceptions.ComputeError`` because ``reduce_over``
-    polls ``fp.is_file()`` and reads the partial parquet file.
-    """
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        in_fps = [tmp / f"in_{i}.parquet" for i in range(2)]
-        out_fp = tmp / "out.parquet"
+    df0 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df1 = pl.DataFrame({"a": [5, 6], "b": [7, 8]})
 
-        df0 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-        df1 = pl.DataFrame({"a": [5, 6], "b": [7, 8]})
+    write_df(df0, in_fps[0])
 
-        write_df(df0, in_fps[0])
-
-        touched = threading.Event()
-        slow_writer = threading.Thread(
-            target=_publish_before_complete_write,
-            args=(df1, in_fps[1], touched, _RACE_WINDOW_SECONDS),
+    touched = threading.Event()
+    slow_writer = threading.Thread(
+        target=_publish_before_complete_write,
+        args=(df1, in_fps[1], touched, _RACE_WINDOW_SECONDS),
+    )
+    slow_writer.start()
+    try:
+        # Explicit handshake: proceed only once the partial file exists.
+        assert touched.wait(timeout=5.0), "writer thread never created the partial file"
+        reduce_over(
+            in_fps=in_fps,
+            out_fp=out_fp,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=_reduce_fn,
+            polling_time=0.005,
         )
-        slow_writer.start()
-        try:
-            # Explicit handshake: proceed only once the partial file exists.
-            assert touched.wait(timeout=5.0), "writer thread never created the partial file"
-            reduce_over(
-                in_fps=in_fps,
-                out_fp=out_fp,
-                read_fn=read_df,
-                write_fn=write_df,
-                reduce_fn=_reduce_fn,
-                polling_time=0.005,
-            )
-        finally:
-            slow_writer.join()
+    finally:
+        slow_writer.join(timeout=5.0)
 
-        # ``read_df`` returns a LazyFrame; collect before comparing.
-        result = read_df(out_fp).collect().sort("a")
-        expected = pl.concat([df0, df1], how="vertical").sort("a")
-        assert_frame_equal(result, expected)
+    # ``read_df`` returns a LazyFrame; collect before comparing.
+    result = read_df(out_fp).collect().sort("a")
+    expected = pl.concat([df0, df1], how="vertical").sort("a")
+    # check_dtypes=False because ``reduce_over`` calls ``shrink_dtype`` on numeric columns.
+    assert_frame_equal(result, expected, check_dtypes=False)
 
 
-def test_reduce_over_times_out_on_permanently_invalid_input() -> None:
+def test_reduce_over_times_out_on_permanently_invalid_input(tmp_path: Path) -> None:
     """A permanently invalid (empty) parquet should time out, not hang forever."""
-    import pytest
+    in_fps = [tmp_path / "ok.parquet", tmp_path / "broken.parquet"]
+    out_fp = tmp_path / "out.parquet"
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        in_fps = [tmp / "ok.parquet", tmp / "broken.parquet"]
-        out_fp = tmp / "out.parquet"
+    write_df(pl.DataFrame({"a": [1]}), in_fps[0])
+    in_fps[1].touch()  # exists but invalid parquet, never fixed
 
-        write_df(pl.DataFrame({"a": [1]}), in_fps[0])
-        in_fps[1].touch()  # exists but invalid parquet, never fixed
-
-        with pytest.raises(TimeoutError, match="Timed out"):
-            reduce_over(
-                in_fps=in_fps,
-                out_fp=out_fp,
-                read_fn=read_df,
-                write_fn=write_df,
-                reduce_fn=_reduce_fn,
-                polling_time=0.01,
-                max_poll_time=0.3,
-            )
+    with pytest.raises(TimeoutError, match="Timed out"):
+        reduce_over(
+            in_fps=in_fps,
+            out_fp=out_fp,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=_reduce_fn,
+            polling_time=0.01,
+            max_poll_time=0.3,
+        )
 
 
-def test_reduce_over_rejects_max_poll_time_not_larger_than_polling_time() -> None:
+def test_reduce_over_rejects_max_poll_time_not_larger_than_polling_time(tmp_path: Path) -> None:
     """``max_poll_time`` must exceed ``polling_time`` to avoid spurious timeouts on the first poll."""
-    import pytest
+    in_fps = [tmp_path / "a.parquet"]
+    out_fp = tmp_path / "out.parquet"
 
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        in_fps = [tmp / "a.parquet"]
-        out_fp = tmp / "out.parquet"
-
-        with pytest.raises(ValueError, match="must be greater than"):
-            reduce_over(
-                in_fps=in_fps,
-                out_fp=out_fp,
-                read_fn=read_df,
-                write_fn=write_df,
-                reduce_fn=_reduce_fn,
-                polling_time=1.0,
-                max_poll_time=1.0,
-            )
+    with pytest.raises(ValueError, match="must be greater than"):
+        reduce_over(
+            in_fps=in_fps,
+            out_fp=out_fp,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=_reduce_fn,
+            polling_time=1.0,
+            max_poll_time=1.0,
+        )

--- a/tests/test_reducer_race.py
+++ b/tests/test_reducer_race.py
@@ -112,3 +112,24 @@ def test_reduce_over_times_out_on_permanently_invalid_input() -> None:
                 polling_time=0.01,
                 max_poll_time=0.3,
             )
+
+
+def test_reduce_over_rejects_max_poll_time_not_larger_than_polling_time() -> None:
+    """``max_poll_time`` must exceed ``polling_time`` to avoid spurious timeouts on the first poll."""
+    import pytest
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        in_fps = [tmp / "a.parquet"]
+        out_fp = tmp / "out.parquet"
+
+        with pytest.raises(ValueError, match="must be greater than"):
+            reduce_over(
+                in_fps=in_fps,
+                out_fp=out_fp,
+                read_fn=read_df,
+                write_fn=write_df,
+                reduce_fn=_reduce_fn,
+                polling_time=1.0,
+                max_poll_time=1.0,
+            )

--- a/tests/test_write_df_atomic.py
+++ b/tests/test_write_df_atomic.py
@@ -1,0 +1,78 @@
+"""Tests for the atomic-publish behavior of :func:`MEDS_transforms.dataframe.write_df`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import polars as pl
+import pytest
+
+from MEDS_transforms.dataframe import write_df
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_write_df_publishes_final_file(tmp_path: Path) -> None:
+    """Happy path: the final file exists, the staging .tmp file does not."""
+    out_fp = tmp_path / "out.parquet"
+    write_df(pl.DataFrame({"a": [1, 2, 3]}), out_fp)
+
+    assert out_fp.is_file()
+    assert not out_fp.with_suffix(".parquet.tmp").exists()
+
+
+def test_write_df_creates_parent_directory(tmp_path: Path) -> None:
+    """Missing parent dirs should be created by write_df (covers the mkdir branch)."""
+    out_fp = tmp_path / "nested" / "deeper" / "out.parquet"
+    assert not out_fp.parent.exists()
+    write_df(pl.DataFrame({"a": [1]}), out_fp)
+    assert out_fp.is_file()
+
+
+def test_write_df_collects_lazyframe(tmp_path: Path) -> None:
+    """A LazyFrame should be collected and written as parquet."""
+    out_fp = tmp_path / "out.parquet"
+    write_df(pl.LazyFrame({"a": [1, 2, 3]}), out_fp)
+    assert out_fp.is_file()
+    assert pl.read_parquet(out_fp)["a"].to_list() == [1, 2, 3]
+
+
+def test_write_df_cleans_up_tmp_file_on_rename_failure(tmp_path: Path) -> None:
+    """If ``os.replace`` raises after the tmp parquet is written, the tmp file is unlinked and the original
+    exception propagates.
+
+    The final ``out_fp`` should remain untouched.
+    """
+    out_fp = tmp_path / "out.parquet"
+    tmp_fp = out_fp.with_suffix(".parquet.tmp")
+
+    with (
+        patch("MEDS_transforms.dataframe.write_fn.os.replace", side_effect=OSError("boom")),
+        pytest.raises(OSError, match="boom"),
+    ):
+        write_df(pl.DataFrame({"a": [1]}), out_fp)
+
+    assert not tmp_fp.exists(), "staging .tmp file should be cleaned up on failure"
+    assert not out_fp.exists(), "final output must not appear when rename failed"
+
+
+def test_write_df_cleans_up_tmp_file_on_write_failure(tmp_path: Path) -> None:
+    """If ``df.write_parquet`` raises, any partial tmp file should be cleaned up too."""
+    out_fp = tmp_path / "out.parquet"
+    tmp_fp = out_fp.with_suffix(".parquet.tmp")
+
+    def _explode(self, *args, **kwargs):
+        # Simulate a mid-write failure: create the tmp file, then raise.
+        tmp_fp.write_bytes(b"partial")
+        raise RuntimeError("write_parquet exploded")
+
+    with (
+        patch("polars.DataFrame.write_parquet", new=_explode),
+        pytest.raises(RuntimeError, match="exploded"),
+    ):
+        write_df(pl.DataFrame({"a": [1]}), out_fp)
+
+    assert not tmp_fp.exists(), "staging .tmp file should be cleaned up on failure"
+    assert not out_fp.exists()


### PR DESCRIPTION
## Summary

Fixes the mapreduce reducer race condition reported in #373. Originally this PR only added a failing regression test; PR #375 (now merged into this branch) added the fix, and a follow-up commit brought the patch to 100% line coverage.

### The bug

`reduce_over` used to poll for mapper outputs with `fp.is_file()`, which returns True as soon as the mapper *creates* `fp` — well before `df.write_parquet(fp)` has flushed a valid `PAR1` footer. The reducer then called `read_fn(fp)` on a partial parquet and raised:

```
polars.exceptions.ComputeError: parquet: File out of specification: The file must end with PAR1
```

### The fix — two complementary defenses

1. **Atomic writer-side publish** (`write_df`): stage to `<out_fp>.tmp`, then `os.replace` to `out_fp`. On POSIX (and same-filesystem Windows) the rename is atomic, so concurrent readers never observe a partial parquet at the final path. `except BaseException` unlinks the staging file so a mid-write failure leaves nothing behind.
2. **Completeness-aware reader-side poll** (`reduce_over`): the readiness loop now uses `default_file_checker`, which opens the parquet to verify the footer, instead of `Path.is_file()`. Defensive even if a caller-supplied `write_fn` isn't atomic.

The poll loop also grew an optional `max_poll_time` so a permanently-stuck / corrupt input produces a `TimeoutError` instead of hanging the reducer. `TimeoutError` messages distinguish `present but unreadable:` from `missing:` inputs.

### What's in this PR

| File | Change |
|---|---|
| `src/MEDS_transforms/dataframe/write_fn.py` | `write_df` now writes to `<out_fp>.tmp` and `os.replace`s to `out_fp`; cleans up staging file on any exception. |
| `src/MEDS_transforms/mapreduce/reducer.py` | `reduce_over` polls with `default_file_checker`, caches once-validated inputs, optional `max_poll_time` with bounded sleep (`min(polling_time, remaining)`), targeted `TimeoutError` messages. |
| `tests/test_reducer_race.py` | Four deterministic tests: the original race reproduction (now passing with the fix), timeout on a permanently-invalid parquet, timeout on a missing-entirely input, and the `max_poll_time <= polling_time` guard. |
| `tests/test_write_df_atomic.py` | Five tests: happy path, parent-dir creation, `LazyFrame` input, cleanup on `os.replace` failure, cleanup on mid-`write_parquet` failure. |

### Test plan

- [x] `uv run pytest tests/test_reducer_race.py tests/test_write_df_atomic.py`: **9 passed**
- [x] Full non-parallel suite (`tests/ + src/MEDS_transforms/`): **152 passed**
- [x] Coverage on the patch files: `write_fn.py` **100%**, `reducer.py` **100%**

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)