### PR TITLE
Dynamic quantile schema for aggregate_code_metadata (closes #342)

### DIFF
--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -788,14 +788,7 @@ def reducer_fntr(
     return reducer
 
 
-AGGREGATION_SCHEMA_UPDATES = {
-    "values/quantiles": pl.Struct(
-        {
-            "values/quantile/0.25": pl.Float32,
-            "values/quantile/0.5": pl.Float32,
-            "values/quantile/0.75": pl.Float32,
-        }
-    ),
+AGGREGATION_SCHEMA_UPDATES_BASE = {
     "code/n_occurrences": pl.UInt8,
     "code/n_subjects": pl.UInt8,
     "values/n_occurrences": pl.UInt8,
@@ -808,6 +801,52 @@ AGGREGATION_SCHEMA_UPDATES = {
 }
 
 
+def _quantiles_schema(aggregations: list) -> pl.Struct | None:
+    """Build the ``values/quantiles`` struct schema for the quantile list declared in ``aggregations``.
+
+    Returns ``None`` when no ``values/quantiles`` aggregation is declared.
+
+    Examples:
+        >>> _quantiles_schema(["code/n_occurrences"]) is None
+        True
+        >>> s = _quantiles_schema([{"name": "values/quantiles", "quantiles": [0.1, 0.5, 0.9]}])
+        >>> list(s.fields)
+        [Field('values/quantile/0.1', Float32), Field('values/quantile/0.5', Float32), Field('values/quantile/0.9', Float32)]
+        >>> s = _quantiles_schema([{"name": "values/quantiles", "quantiles": [0.25, 0.75]}])
+        >>> list(s.fields)
+        [Field('values/quantile/0.25', Float32), Field('values/quantile/0.75', Float32)]
+    """  # noqa: E501
+    for agg in aggregations or []:
+        if isinstance(agg, dict) and agg.get("name") == "values/quantiles":
+            qs = agg.get("quantiles", []) or []
+            return pl.Struct({f"values/quantile/{q}": pl.Float32 for q in qs})
+    return None
+
+
+def aggregation_schema_updates(stage_cfg: dict | None = None) -> dict[str, pl.DataType]:
+    """Compose the example-time output schema overrides for this stage, including dynamic quantiles.
+
+    Static column types (``code/n_occurrences``, ``values/sum``, etc.) are always emitted. The
+    ``values/quantiles`` struct is generated from the example's ``aggregations`` config so that
+    non-default ``probs`` round-trip correctly (see issue #342).
+
+    Examples:
+        >>> aggregation_schema_updates({"aggregations": ["code/n_occurrences"]})["values/sum"]
+        Float32
+        >>> "values/quantiles" in aggregation_schema_updates({"aggregations": ["code/n_occurrences"]})
+        False
+        >>> cfg = {"aggregations": [{"name": "values/quantiles", "quantiles": [0.1, 0.9]}]}
+        >>> list(aggregation_schema_updates(cfg)["values/quantiles"].fields)
+        [Field('values/quantile/0.1', Float32), Field('values/quantile/0.9', Float32)]
+    """
+    updates = dict(AGGREGATION_SCHEMA_UPDATES_BASE)
+    if stage_cfg:
+        quantiles_struct = _quantiles_schema(stage_cfg.get("aggregations"))
+        if quantiles_struct is not None:
+            updates["values/quantiles"] = quantiles_struct
+    return updates
+
+
 stage = Stage.register(
-    map_fn=mapper_fntr, reduce_fn=reducer_fntr, output_schema_updates=AGGREGATION_SCHEMA_UPDATES
+    map_fn=mapper_fntr, reduce_fn=reducer_fntr, output_schema_updates=aggregation_schema_updates
 )

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -833,7 +833,8 @@ def aggregation_schema_updates(stage_cfg: dict | None = None) -> dict[str, pl.Da
 
     Static column types (``code/n_occurrences``, ``values/sum``, etc.) are always emitted. The
     ``values/quantiles`` struct is generated from the example's ``aggregations`` config so that
-    non-default ``probs`` round-trip correctly (see issue #342).
+    non-default ``quantiles`` (i.e. the quantile probabilities) round-trip correctly (see
+    issue #342).
 
     Examples:
         >>> from pprint import pprint

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -810,12 +810,17 @@ def _quantiles_schema(aggregations: list) -> pl.Struct | None:
         >>> _quantiles_schema(["code/n_occurrences"]) is None
         True
         >>> s = _quantiles_schema([{"name": "values/quantiles", "quantiles": [0.1, 0.5, 0.9]}])
-        >>> list(s.fields)
-        [Field('values/quantile/0.1', Float32), Field('values/quantile/0.5', Float32), Field('values/quantile/0.9', Float32)]
+        >>> for f in s.fields:
+        ...     print(f)
+        Field('values/quantile/0.1', Float32)
+        Field('values/quantile/0.5', Float32)
+        Field('values/quantile/0.9', Float32)
         >>> s = _quantiles_schema([{"name": "values/quantiles", "quantiles": [0.25, 0.75]}])
-        >>> list(s.fields)
-        [Field('values/quantile/0.25', Float32), Field('values/quantile/0.75', Float32)]
-    """  # noqa: E501
+        >>> for f in s.fields:
+        ...     print(f)
+        Field('values/quantile/0.25', Float32)
+        Field('values/quantile/0.75', Float32)
+    """
     for agg in aggregations or []:
         if isinstance(agg, dict) and agg.get("name") == "values/quantiles":
             qs = agg.get("quantiles", []) or []
@@ -831,13 +836,29 @@ def aggregation_schema_updates(stage_cfg: dict | None = None) -> dict[str, pl.Da
     non-default ``probs`` round-trip correctly (see issue #342).
 
     Examples:
-        >>> aggregation_schema_updates({"aggregations": ["code/n_occurrences"]})["values/sum"]
-        Float32
-        >>> "values/quantiles" in aggregation_schema_updates({"aggregations": ["code/n_occurrences"]})
-        False
+        >>> from pprint import pprint
+        >>> pprint(aggregation_schema_updates({"aggregations": ["code/n_occurrences"]}))
+        {'code/n_occurrences': UInt8,
+         'code/n_subjects': UInt8,
+         'values/max': Float32,
+         'values/min': Float32,
+         'values/n_ints': UInt8,
+         'values/n_occurrences': UInt8,
+         'values/n_subjects': UInt8,
+         'values/sum': Float32,
+         'values/sum_sqd': Float32}
         >>> cfg = {"aggregations": [{"name": "values/quantiles", "quantiles": [0.1, 0.9]}]}
-        >>> list(aggregation_schema_updates(cfg)["values/quantiles"].fields)
-        [Field('values/quantile/0.1', Float32), Field('values/quantile/0.9', Float32)]
+        >>> pprint(aggregation_schema_updates(cfg))
+        {'code/n_occurrences': UInt8,
+         'code/n_subjects': UInt8,
+         'values/max': Float32,
+         'values/min': Float32,
+         'values/n_ints': UInt8,
+         'values/n_occurrences': UInt8,
+         'values/n_subjects': UInt8,
+         'values/quantiles': Struct({'values/quantile/0.1': Float32, 'values/quantile/0.9': Float32}),
+         'values/sum': Float32,
+         'values/sum_sqd': Float32}
     """
     updates = dict(AGGREGATION_SCHEMA_UPDATES_BASE)
     if stage_cfg:

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/README.md
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/README.md
@@ -4,8 +4,8 @@ These examples show `aggregate_code_metadata` in several contexts:
     the default quantiles (`0.25 / 0.5 / 0.75`), counts, and distribution statistics on the full
     static sample data.
 - **with_custom_quantiles** -- same data but with user-chosen `quantiles: [0.1, 0.9]`. The
-    `values/quantiles` struct schema is generated from the stage config, so non-default `probs`
-    round-trip through example validation (see issue #342).
+    `values/quantiles` struct schema is generated from the stage config, so non-default
+    `quantiles` round-trip through example validation (see issue #342).
 - **in_example_pipeline/fit_normalization** -- collects only the statistics needed for z-score
     normalization (`n_occurrences`, `n_subjects`, `sum`, `sum_sqd`).
 - **in_example_pipeline/fit_outlier_detection** -- collects only the statistics needed for outlier

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/README.md
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/README.md
@@ -1,7 +1,11 @@
 These examples show `aggregate_code_metadata` in several contexts:
 
 - **on_raw_static_data** and **with_not_split_defined_shards** -- comprehensive aggregation with
-    quantiles, counts, and distribution statistics on the full static sample data.
+    the default quantiles (`0.25 / 0.5 / 0.75`), counts, and distribution statistics on the full
+    static sample data.
+- **with_custom_quantiles** -- same data but with user-chosen `quantiles: [0.1, 0.9]`. The
+    `values/quantiles` struct schema is generated from the stage config, so non-default `probs`
+    round-trip through example validation (see issue #342).
 - **in_example_pipeline/fit_normalization** -- collects only the statistics needed for z-score
     normalization (`n_occurrences`, `n_subjects`, `sum`, `sum_sqd`).
 - **in_example_pipeline/fit_outlier_detection** -- collects only the statistics needed for outlier

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/_test_cfg.yaml
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/_test_cfg.yaml
@@ -1,0 +1,1 @@
+do_use_config_yaml: True

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/cfg.yaml
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/cfg.yaml
@@ -1,0 +1,15 @@
+aggregations:
+  - code/n_occurrences
+  - code/n_subjects
+  - values/n_occurrences
+  - values/n_subjects
+  - values/sum
+  - values/sum_sqd
+  - values/n_ints
+  - values/min
+  - values/max
+  - name: values/quantiles
+    quantiles:
+      - 0.1
+      - 0.9
+do_summarize_over_all_codes: True

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/cfg.yaml
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/cfg.yaml
@@ -1,13 +1,4 @@
 aggregations:
-  - code/n_occurrences
-  - code/n_subjects
-  - values/n_occurrences
-  - values/n_subjects
-  - values/sum
-  - values/sum_sqd
-  - values/n_ints
-  - values/min
-  - values/max
   - name: values/quantiles
     quantiles:
       - 0.1

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/out_metadata.yaml
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/out_metadata.yaml
@@ -1,0 +1,176 @@
+metadata/codes.parquet:
+  - code: null
+    code/n_occurrences: 44
+    code/n_subjects: 4
+    values/n_occurrences: 28
+    values/n_subjects: 4
+    values/sum: 3198.8389005974336
+    values/sum_sqd: 382968.28937288234
+    values/n_ints: 6
+    values/min: 86.0
+    values/max: 175.271118
+    values/quantiles:
+      values/quantile/0.1: 96.0
+      values/quantile/0.9: 160.395309
+    description: null
+    parent_codes: null
+
+  - code: "ADMISSION//CARDIAC"
+    code/n_occurrences: 2
+    code/n_subjects: 2
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: null
+    parent_codes: null
+
+  - code: "ADMISSION//ORTHOPEDIC"
+    code/n_occurrences: 1
+    code/n_subjects: 1
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: null
+    parent_codes: null
+
+  - code: "ADMISSION//PULMONARY"
+    code/n_occurrences: 1
+    code/n_subjects: 1
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: null
+    parent_codes: null
+
+  - code: "DISCHARGE"
+    code/n_occurrences: 4
+    code/n_subjects: 4
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: null
+    parent_codes: null
+
+  - code: "EYE_COLOR//BLUE"
+    code/n_occurrences: 1
+    code/n_subjects: 1
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: "Blue Eyes. Less common than brown."
+    parent_codes: null
+
+  - code: "EYE_COLOR//BROWN"
+    code/n_occurrences: 1
+    code/n_subjects: 1
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: "Brown Eyes. The most common eye color."
+    parent_codes: null
+
+  - code: "EYE_COLOR//HAZEL"
+    code/n_occurrences: 2
+    code/n_subjects: 2
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: "Hazel eyes. These are uncommon"
+    parent_codes: null
+
+  - code: "HEIGHT"
+    code/n_occurrences: 4
+    code/n_subjects: 4
+    values/n_occurrences: 4
+    values/n_subjects: 4
+    values/sum: 656.8389005974336
+    values/sum_sqd: 108056.12937288235
+    values/n_ints: 0
+    values/min: 156.485596
+    values/max: 175.271118
+    values/quantiles:
+      values/quantile/0.1: 156.485596
+      values/quantile/0.9: 175.271118
+    description: null
+    parent_codes: null
+
+  - code: "HR"
+    code/n_occurrences: 12
+    code/n_subjects: 4
+    values/n_occurrences: 12
+    values/n_subjects: 4
+    values/sum: 1360.5000000000002
+    values/sum_sqd: 158538.77
+    values/n_ints: 2
+    values/min: 86.0
+    values/max: 170.199997
+    values/quantiles:
+      values/quantile/0.1: 102.6
+      values/quantile/0.9: 119.800003
+    description: "Heart Rate"
+    parent_codes: ["LOINC/8867-4"]
+
+  - code: "MEDS_BIRTH"
+    code/n_occurrences: 4
+    code/n_subjects: 4
+    values/n_occurrences: 0
+    values/n_subjects: 0
+    values/sum: 0
+    values/sum_sqd: 0
+    values/n_ints: 0
+    values/min: null
+    values/max: null
+    values/quantiles: null
+    description: null
+    parent_codes: null
+
+  - code: "TEMP"
+    code/n_occurrences: 12
+    code/n_subjects: 4
+    values/n_occurrences: 12
+    values/n_subjects: 4
+    values/sum: 1181.4999999999998
+    values/sum_sqd: 116373.38999999998
+    values/n_ints: 4
+    values/min: 95.5
+    values/max: 100.400002
+    values/quantiles:
+      values/quantile/0.1: 95.800003
+      values/quantile/0.9: 100.099998
+    description: "Body Temperature"
+    parent_codes: ["LOINC/8310-5"]

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/out_metadata.yaml
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/examples/with_custom_quantiles/out_metadata.yaml
@@ -1,14 +1,5 @@
 metadata/codes.parquet:
   - code: null
-    code/n_occurrences: 44
-    code/n_subjects: 4
-    values/n_occurrences: 28
-    values/n_subjects: 4
-    values/sum: 3198.8389005974336
-    values/sum_sqd: 382968.28937288234
-    values/n_ints: 6
-    values/min: 86.0
-    values/max: 175.271118
     values/quantiles:
       values/quantile/0.1: 96.0
       values/quantile/0.9: 160.395309
@@ -16,113 +7,41 @@ metadata/codes.parquet:
     parent_codes: null
 
   - code: "ADMISSION//CARDIAC"
-    code/n_occurrences: 2
-    code/n_subjects: 2
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: null
     parent_codes: null
 
   - code: "ADMISSION//ORTHOPEDIC"
-    code/n_occurrences: 1
-    code/n_subjects: 1
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: null
     parent_codes: null
 
   - code: "ADMISSION//PULMONARY"
-    code/n_occurrences: 1
-    code/n_subjects: 1
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: null
     parent_codes: null
 
   - code: "DISCHARGE"
-    code/n_occurrences: 4
-    code/n_subjects: 4
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: null
     parent_codes: null
 
   - code: "EYE_COLOR//BLUE"
-    code/n_occurrences: 1
-    code/n_subjects: 1
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: "Blue Eyes. Less common than brown."
     parent_codes: null
 
   - code: "EYE_COLOR//BROWN"
-    code/n_occurrences: 1
-    code/n_subjects: 1
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: "Brown Eyes. The most common eye color."
     parent_codes: null
 
   - code: "EYE_COLOR//HAZEL"
-    code/n_occurrences: 2
-    code/n_subjects: 2
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: "Hazel eyes. These are uncommon"
     parent_codes: null
 
   - code: "HEIGHT"
-    code/n_occurrences: 4
-    code/n_subjects: 4
-    values/n_occurrences: 4
-    values/n_subjects: 4
-    values/sum: 656.8389005974336
-    values/sum_sqd: 108056.12937288235
-    values/n_ints: 0
-    values/min: 156.485596
-    values/max: 175.271118
     values/quantiles:
       values/quantile/0.1: 156.485596
       values/quantile/0.9: 175.271118
@@ -130,15 +49,6 @@ metadata/codes.parquet:
     parent_codes: null
 
   - code: "HR"
-    code/n_occurrences: 12
-    code/n_subjects: 4
-    values/n_occurrences: 12
-    values/n_subjects: 4
-    values/sum: 1360.5000000000002
-    values/sum_sqd: 158538.77
-    values/n_ints: 2
-    values/min: 86.0
-    values/max: 170.199997
     values/quantiles:
       values/quantile/0.1: 102.6
       values/quantile/0.9: 119.800003
@@ -146,29 +56,11 @@ metadata/codes.parquet:
     parent_codes: ["LOINC/8867-4"]
 
   - code: "MEDS_BIRTH"
-    code/n_occurrences: 4
-    code/n_subjects: 4
-    values/n_occurrences: 0
-    values/n_subjects: 0
-    values/sum: 0
-    values/sum_sqd: 0
-    values/n_ints: 0
-    values/min: null
-    values/max: null
     values/quantiles: null
     description: null
     parent_codes: null
 
   - code: "TEMP"
-    code/n_occurrences: 12
-    code/n_subjects: 4
-    values/n_occurrences: 12
-    values/n_subjects: 4
-    values/sum: 1181.4999999999998
-    values/sum_sqd: 116373.38999999998
-    values/n_ints: 4
-    values/min: 95.5
-    values/max: 100.400002
     values/quantiles:
       values/quantile/0.1: 95.800003
       values/quantile/0.9: 100.099998

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -744,10 +744,44 @@ class Stage:
            behavior even when no example is in scope).
         4. ``None`` as a last resort.
 
-        If ``output_schema_updates`` is a plain dict (or None), it is returned unchanged.
+        If ``output_schema_updates`` is a plain dict, it is returned unchanged.
+
+        Examples:
+            Dict overrides are returned verbatim (and the returned dict is a fresh copy):
+
+            >>> stage = Stage.register(
+            ...     stage_name="dict_stage",
+            ...     stage_docstring="x",
+            ...     map_fn=lambda df: df,
+            ...     output_schema_updates={"foo": pl.Int64},
+            ... )
+            >>> stage._resolve_output_schema_updates()
+            {'foo': Int64}
+
+            Callable overrides receive the resolved ``stage_cfg``. Priority: explicit
+            ``stage_cfg`` arg, then ``example_dir/cfg.yaml``, then ``default_config``:
+
+            >>> def schema_fn(cfg):
+            ...     return {"probs": cfg["probs"] if cfg else "(no cfg)"}
+            >>> stage = Stage.register(
+            ...     stage_name="callable_stage",
+            ...     stage_docstring="x",
+            ...     map_fn=lambda df: df,
+            ...     output_schema_updates=schema_fn,
+            ...     default_config={"probs": "from-default"},
+            ... )
+            >>> stage._resolve_output_schema_updates(stage_cfg={"probs": "from-arg"})
+            {'probs': 'from-arg'}
+            >>> import tempfile
+            >>> with tempfile.TemporaryDirectory() as td:
+            ...     example_dir = Path(td)
+            ...     (example_dir / "cfg.yaml").write_text("probs: from-example\\n")
+            ...     stage._resolve_output_schema_updates(example_dir)
+            20
+            {'probs': 'from-example'}
+            >>> stage._resolve_output_schema_updates()
+            {'probs': 'from-default'}
         """
-        if self.output_schema_updates is None:
-            return {}
         if not callable(self.output_schema_updates):
             return dict(self.output_schema_updates)
 

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -476,7 +476,9 @@ class Stage:
     read_fn: READ_FN_T | None = None
     write_fn: WRITE_FN_T | None = None
 
-    output_schema_updates: dict[str, pl.DataType] | None = None
+    output_schema_updates: dict[str, pl.DataType] | Callable[[dict | None], dict[str, pl.DataType]] | None = (
+        None
+    )
     is_metadata: bool | None = None
 
     __mimic_fn: Callable | None = None
@@ -538,7 +540,9 @@ class Stage:
         write_fn: WRITE_FN_T | None = None,
         stage_name: str | None = None,
         stage_docstring: str | None = None,
-        output_schema_updates: dict[str, pl.DataType] | None = None,
+        output_schema_updates: (
+            dict[str, pl.DataType] | Callable[[dict | None], dict[str, pl.DataType]] | None
+        ) = None,
         examples_dir: Path | None = None,
         default_config: dict[str, Any] | DictConfig | Path | str | None = None,
         is_metadata: bool | None = None,
@@ -604,6 +608,8 @@ class Stage:
 
         if output_schema_updates is None:
             self.output_schema_updates = {}
+        elif callable(output_schema_updates):
+            self.output_schema_updates = output_schema_updates
         else:
             self.output_schema_updates = copy.deepcopy(output_schema_updates)
 
@@ -721,6 +727,24 @@ class Stage:
                     f"{type(default_config)}: {default_config}"
                 )
 
+    def _resolve_output_schema_updates(self, example_dir: Path | None = None) -> dict[str, pl.DataType]:
+        """Resolve ``output_schema_updates`` against an optional example directory.
+
+        If ``output_schema_updates`` is a callable, it is called with the example's parsed
+        ``cfg.yaml`` (or ``None`` when there is none) and expected to return a dict. Otherwise the
+        dict is returned as-is.
+        """
+        if self.output_schema_updates is None:
+            return {}
+        if not callable(self.output_schema_updates):
+            return dict(self.output_schema_updates)
+        stage_cfg: dict | None = None
+        if example_dir is not None:
+            stage_cfg_fp = example_dir / "cfg.yaml"
+            if stage_cfg_fp.is_file():
+                stage_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp))
+        return dict(self.output_schema_updates(stage_cfg))
+
     @property
     def test_cases(self) -> dict[str, StageExample]:
         if self.examples_dir is None:
@@ -737,11 +761,12 @@ class Stage:
 
             if self.example_class.is_example_dir(example_dir):
                 scenario_name = example_dir.relative_to(self.examples_dir).as_posix()
+                schema_updates = self._resolve_output_schema_updates(example_dir)
                 test_cases[scenario_name] = self.example_class.from_dir(
                     stage_name=self.stage_name,
                     scenario_name=scenario_name,
                     example_dir=example_dir,
-                    **self.output_schema_updates,
+                    **schema_updates,
                 )
             else:
                 examples_to_check.extend(sorted(example_dir.iterdir()))
@@ -951,9 +976,10 @@ class Stage:
             lines.append("  Default config:")
             lines.extend(textwrap.indent(str(OmegaConf.to_yaml(self.default_config)), "    | ").splitlines())
 
-        if self.output_schema_updates:
+        schema_updates = self._resolve_output_schema_updates()
+        if schema_updates:
             lines.append("  Output schema updates:")
-            lines.extend(pretty_wrap(str(self.output_schema_updates)))
+            lines.extend(pretty_wrap(str(schema_updates)))
 
         lines.extend(
             [

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -155,8 +155,11 @@ class Stage:
         examples_dir: A directory containing nested test cases for the stage.
             If not set, this is automatically inferred in the case that the stage name and registering file
             conform to the pattern mentioned above.
-        output_schema_updates: A dictionary mapping column name to a Polars type for the output of the stage,
-            with the base MEDS schema options as defaults for unspecified columns.
+        output_schema_updates: Column-name → Polars-type overrides for the stage's output, layered
+            on top of the base MEDS schema. Either a plain dict, or a callable
+            ``(stage_cfg) -> dict`` that derives the overrides from the stage's effective config
+            (``default_config`` deep-merged with the example/pipeline overrides). Use the callable
+            form when the schema depends on user-chosen config, e.g. quantile probabilities.
         default_config: A dictionary containing the default configuration options for the stage. This can be
             passed manually during registration or is set automatically based on the calling file location in
             a manner similar to the examples directory.
@@ -736,13 +739,17 @@ class Stage:
         """Resolve ``output_schema_updates`` against an optional example or pre-parsed config.
 
         If ``output_schema_updates`` is a callable, it is called with a ``stage_cfg`` dict and
-        expected to return a dict. Resolution order for that dict:
+        expected to return a dict. The argument is built by starting from ``self.default_config``
+        (if any) and deep-merging the example's overrides on top, mirroring what the pipeline
+        runner does at execution time:
 
-        1. Explicit ``stage_cfg`` argument (lets callers parse ``cfg.yaml`` once and share).
-        2. ``example_dir / "cfg.yaml"`` if ``example_dir`` is given and the file exists.
-        3. ``self.default_config`` (so ``Stage.__str__`` / ``docgen`` reflect the stage's default
-           behavior even when no example is in scope).
-        4. ``None`` as a last resort.
+        1. Base layer: ``self.default_config`` (may be empty).
+        2. Overrides (takes precedence, first non-``None`` wins):
+            a. Explicit ``stage_cfg`` argument (lets callers parse ``cfg.yaml`` once and share).
+            b. ``example_dir / "cfg.yaml"`` if ``example_dir`` is given and the file exists.
+
+        If neither overrides nor default config is available, the callable is invoked with
+        ``None``.
 
         If ``output_schema_updates`` is a plain dict, it is returned unchanged.
 
@@ -758,39 +765,48 @@ class Stage:
             >>> stage._resolve_output_schema_updates()
             {'foo': Int64}
 
-            Callable overrides receive the resolved ``stage_cfg``. Priority: explicit
-            ``stage_cfg`` arg, then ``example_dir/cfg.yaml``, then ``default_config``:
+            Callable overrides receive the effective config (``default_config`` merged with the
+            example or arg overrides). Keys unique to ``default_config`` survive the merge, and
+            override values take precedence on conflict:
 
             >>> def schema_fn(cfg):
-            ...     return {"probs": cfg["probs"] if cfg else "(no cfg)"}
+            ...     return dict(cfg) if cfg else {"(no cfg)": None}
             >>> stage = Stage.register(
             ...     stage_name="callable_stage",
             ...     stage_docstring="x",
             ...     map_fn=lambda df: df,
             ...     output_schema_updates=schema_fn,
-            ...     default_config={"probs": "from-default"},
+            ...     default_config={"probs": "from-default", "n_bins": 8},
             ... )
             >>> stage._resolve_output_schema_updates(stage_cfg={"probs": "from-arg"})
-            {'probs': 'from-arg'}
+            {'probs': 'from-arg', 'n_bins': 8}
             >>> import tempfile
             >>> with tempfile.TemporaryDirectory() as td:
             ...     example_dir = Path(td)
             ...     _ = (example_dir / "cfg.yaml").write_text("probs: from-example\\n")
             ...     stage._resolve_output_schema_updates(example_dir)
-            {'probs': 'from-example'}
+            {'probs': 'from-example', 'n_bins': 8}
             >>> stage._resolve_output_schema_updates()
-            {'probs': 'from-default'}
+            {'probs': 'from-default', 'n_bins': 8}
         """
         if not callable(self.output_schema_updates):
             return dict(self.output_schema_updates)
 
-        resolved_cfg: dict | None = stage_cfg
-        if resolved_cfg is None and example_dir is not None:
+        override_cfg: dict | None = stage_cfg
+        if override_cfg is None and example_dir is not None:
             stage_cfg_fp = example_dir / "cfg.yaml"
             if stage_cfg_fp.is_file():
-                resolved_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp))
-        if resolved_cfg is None and self.default_config:
-            resolved_cfg = OmegaConf.to_container(self.default_config, resolve=False)
+                override_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp))
+
+        default_cfg = (
+            OmegaConf.to_container(self.default_config, resolve=False) if self.default_config else None
+        )
+
+        if default_cfg and override_cfg:
+            resolved_cfg = OmegaConf.to_container(OmegaConf.merge(default_cfg, override_cfg))
+        else:
+            resolved_cfg = override_cfg if override_cfg is not None else default_cfg
+
         return dict(self.output_schema_updates(resolved_cfg))
 
     @property

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -775,9 +775,8 @@ class Stage:
             >>> import tempfile
             >>> with tempfile.TemporaryDirectory() as td:
             ...     example_dir = Path(td)
-            ...     (example_dir / "cfg.yaml").write_text("probs: from-example\\n")
+            ...     _ = (example_dir / "cfg.yaml").write_text("probs: from-example\\n")
             ...     stage._resolve_output_schema_updates(example_dir)
-            20
             {'probs': 'from-example'}
             >>> stage._resolve_output_schema_updates()
             {'probs': 'from-default'}

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -788,6 +788,12 @@ class Stage:
             {'probs': 'from-example', 'n_bins': 8}
             >>> stage._resolve_output_schema_updates()
             {'probs': 'from-default', 'n_bins': 8}
+
+            An empty override dict still triggers the merge — defaults survive (guarded against
+            the truthiness trap where ``{}`` would otherwise discard ``default_config``):
+
+            >>> stage._resolve_output_schema_updates(stage_cfg={})
+            {'probs': 'from-default', 'n_bins': 8}
         """
         if not callable(self.output_schema_updates):
             return dict(self.output_schema_updates)
@@ -802,7 +808,7 @@ class Stage:
             OmegaConf.to_container(self.default_config, resolve=False) if self.default_config else None
         )
 
-        if default_cfg and override_cfg:
+        if default_cfg is not None and override_cfg is not None:
             resolved_cfg = OmegaConf.to_container(OmegaConf.merge(default_cfg, override_cfg))
         else:
             resolved_cfg = override_cfg if override_cfg is not None else default_cfg

--- a/src/MEDS_transforms/stages/base.py
+++ b/src/MEDS_transforms/stages/base.py
@@ -727,23 +727,38 @@ class Stage:
                     f"{type(default_config)}: {default_config}"
                 )
 
-    def _resolve_output_schema_updates(self, example_dir: Path | None = None) -> dict[str, pl.DataType]:
-        """Resolve ``output_schema_updates`` against an optional example directory.
+    def _resolve_output_schema_updates(
+        self,
+        example_dir: Path | None = None,
+        *,
+        stage_cfg: dict | None = None,
+    ) -> dict[str, pl.DataType]:
+        """Resolve ``output_schema_updates`` against an optional example or pre-parsed config.
 
-        If ``output_schema_updates`` is a callable, it is called with the example's parsed
-        ``cfg.yaml`` (or ``None`` when there is none) and expected to return a dict. Otherwise the
-        dict is returned as-is.
+        If ``output_schema_updates`` is a callable, it is called with a ``stage_cfg`` dict and
+        expected to return a dict. Resolution order for that dict:
+
+        1. Explicit ``stage_cfg`` argument (lets callers parse ``cfg.yaml`` once and share).
+        2. ``example_dir / "cfg.yaml"`` if ``example_dir`` is given and the file exists.
+        3. ``self.default_config`` (so ``Stage.__str__`` / ``docgen`` reflect the stage's default
+           behavior even when no example is in scope).
+        4. ``None`` as a last resort.
+
+        If ``output_schema_updates`` is a plain dict (or None), it is returned unchanged.
         """
         if self.output_schema_updates is None:
             return {}
         if not callable(self.output_schema_updates):
             return dict(self.output_schema_updates)
-        stage_cfg: dict | None = None
-        if example_dir is not None:
+
+        resolved_cfg: dict | None = stage_cfg
+        if resolved_cfg is None and example_dir is not None:
             stage_cfg_fp = example_dir / "cfg.yaml"
             if stage_cfg_fp.is_file():
-                stage_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp))
-        return dict(self.output_schema_updates(stage_cfg))
+                resolved_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp))
+        if resolved_cfg is None and self.default_config:
+            resolved_cfg = OmegaConf.to_container(self.default_config, resolve=False)
+        return dict(self.output_schema_updates(resolved_cfg))
 
     @property
     def test_cases(self) -> dict[str, StageExample]:
@@ -761,11 +776,17 @@ class Stage:
 
             if self.example_class.is_example_dir(example_dir):
                 scenario_name = example_dir.relative_to(self.examples_dir).as_posix()
-                schema_updates = self._resolve_output_schema_updates(example_dir)
+                # Parse cfg.yaml once per example so both the schema resolver and from_dir reuse it.
+                stage_cfg_fp = example_dir / "cfg.yaml"
+                parsed_stage_cfg: dict | None = (
+                    OmegaConf.to_container(OmegaConf.load(stage_cfg_fp)) if stage_cfg_fp.is_file() else None
+                )
+                schema_updates = self._resolve_output_schema_updates(stage_cfg=parsed_stage_cfg)
                 test_cases[scenario_name] = self.example_class.from_dir(
                     stage_name=self.stage_name,
                     scenario_name=scenario_name,
                     example_dir=example_dir,
+                    stage_cfg=parsed_stage_cfg,
                     **schema_updates,
                 )
             else:

--- a/src/MEDS_transforms/stages/docgen.py
+++ b/src/MEDS_transforms/stages/docgen.py
@@ -269,11 +269,12 @@ def _build_stage_content(stage_name: str, stage) -> str:
         lines.extend(["", "## Default Configuration", "", "```yaml", config_yaml, "```"])
 
     # Output schema updates
-    if stage.output_schema_updates:
+    schema_updates = stage._resolve_output_schema_updates()
+    if schema_updates:
         lines.extend(["", "## Output Schema Updates", ""])
         lines.append("| Column | Type |")
         lines.append("| --- | --- |")
-        for col, dtype in stage.output_schema_updates.items():
+        for col, dtype in schema_updates.items():
             lines.append(f"| `{col}` | `{dtype}` |")
 
     # CLI usage

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -881,9 +881,19 @@ class StageExample:
 
     @classmethod
     def from_dir(
-        cls, stage_name: str, scenario_name: str, example_dir: Path, **schema_updates
+        cls,
+        stage_name: str,
+        scenario_name: str,
+        example_dir: Path,
+        *,
+        stage_cfg: dict | None = None,
+        **schema_updates,
     ) -> StageExample:
-        """Parse the example directory and return a StageExample object, or raise an error if invalid."""
+        """Parse the example directory and return a StageExample object, or raise an error if invalid.
+
+        ``stage_cfg`` may be passed in pre-parsed (e.g. by ``Stage.test_cases``) to avoid re-reading
+        ``cfg.yaml``; if ``None`` the file is loaded here as before.
+        """
 
         stage_cfg_fp = example_dir / "cfg.yaml"
         in_fp = example_dir / "in.yaml"
@@ -904,7 +914,8 @@ class StageExample:
                 in_data = MEDSDataset.from_yaml(in_fp)
             except ValueError:
                 in_data = in_fp
-        stage_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp)) if stage_cfg_fp.is_file() else {}
+        if stage_cfg is None:
+            stage_cfg = OmegaConf.to_container(OmegaConf.load(stage_cfg_fp)) if stage_cfg_fp.is_file() else {}
         test_kwargs = OmegaConf.to_container(OmegaConf.load(test_cfg_fp)) if test_cfg_fp.is_file() else {}
         pipeline_cfg = (
             OmegaConf.to_container(OmegaConf.load(pipeline_cfg_fp)) if pipeline_cfg_fp.is_file() else {}


### PR DESCRIPTION
## Summary

Fixes #342. The static ``AGGREGATION_SCHEMA_UPDATES`` dict hardcoded the quantile struct to ``0.25/0.5/0.75``, so users configuring non-default ``probs`` would produce an output whose expected-schema validation inside ``StageExample`` failed (the reducer itself was correct; only the schema override was wrong).

## Changes

1. ``Stage.output_schema_updates`` now accepts either a ``dict`` or a callable ``(stage_cfg) -> dict``. A new ``Stage._resolve_output_schema_updates(example_dir=None)`` helper centralises resolution.
2. ``aggregate_code_metadata`` builds the ``values/quantiles`` ``pl.Struct`` from the example's declared aggregations. Default quantiles continue to produce the same schema as before; non-default ``probs`` now validate correctly.
3. ``Stage.__str__`` and ``docgen.generate_stage_docs`` route through the shared resolver so doc output and pretty-print use the resolved schema.

## Test plan

- [x] New doctests on ``_quantiles_schema`` and ``aggregation_schema_updates`` cover both default and non-default probs.
- [x] Full non-parallel suite: **145 passed**.
- [x] All existing ``aggregate_code_metadata`` examples continue to validate with the dynamic schema.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)