### PR TITLE
Regression test for reshard_to_split single-stage mode (closes #321)

### DIFF
--- a/tests/test_reshard_single_stage.py
+++ b/tests/test_reshard_single_stage.py
@@ -24,19 +24,19 @@ def _write_dataset(input_dir: Path) -> None:
     base_time = datetime(2020, 1, 1, tzinfo=UTC)
 
     def _write(path: Path, subjects: list[int]) -> None:
-        # Use a real timestamp column so reshard_to_split's sort by DataSchema.time_name
-        # hits a well-typed column, matching production MEDS data.
+        # Use real timestamps with the MEDS schema's time dtype so reshard_to_split's sort by
+        # DataSchema.time_name hits a well-typed column that matches production MEDS data.
         rows = [
             {
-                "subject_id": s,
-                "time": base_time.replace(day=1 + i),
-                "code": "A",
-                "numeric_value": None,
+                DataSchema.subject_id_name: s,
+                DataSchema.time_name: base_time.replace(day=1 + i),
+                DataSchema.code_name: "A",
+                DataSchema.numeric_value_name: None,
             }
             for s in subjects
             for i in range(2)
         ]
-        (pl.DataFrame(rows, schema_overrides={DataSchema.time_name: pl.Datetime("us")}).write_parquet(path))
+        pl.DataFrame(rows, schema_overrides={DataSchema.time_name: pl.Datetime("us")}).write_parquet(path)
 
     _write(input_dir / "data" / "train" / "0.parquet", [1, 2, 3, 4])
     _write(input_dir / "data" / "tuning" / "0.parquet", [5, 6])
@@ -44,7 +44,7 @@ def _write_dataset(input_dir: Path) -> None:
 
     splits = pl.DataFrame(
         {
-            "subject_id": [1, 2, 3, 4, 5, 6, 7],
+            DataSchema.subject_id_name: [1, 2, 3, 4, 5, 6, 7],
             "split": ["train"] * 4 + ["tuning"] * 2 + ["held_out"],
         }
     )
@@ -101,4 +101,5 @@ def test_reshard_to_split_runs_as_only_stage() -> None:
             shard_fp = output_dir / "data" / f"{shard_name}.parquet"
             df = pl.read_parquet(shard_fp)
             assert df.height > 0, f"empty shard: {shard_fp}"
-            assert set(df["subject_id"].unique().to_list()) == set(assignment[shard_name])
+            subject_ids = df[DataSchema.subject_id_name].unique().to_list()
+            assert set(subject_ids) == set(assignment[shard_name])

--- a/tests/test_reshard_single_stage.py
+++ b/tests/test_reshard_single_stage.py
@@ -1,0 +1,94 @@
+"""Regression test for https://github.com/mmcdermott/MEDS_transforms/issues/321.
+
+Confirms ``reshard_to_split`` runs correctly when invoked through
+``MEDS_transform-stage`` as the only stage in a pipeline (single-stage mode).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import polars as pl
+from meds import subject_splits_filepath
+
+
+def _write_dataset(input_dir: Path) -> None:
+    (input_dir / "data" / "train").mkdir(parents=True, exist_ok=True)
+    (input_dir / "data" / "tuning").mkdir(parents=True, exist_ok=True)
+    (input_dir / "data" / "held_out").mkdir(parents=True, exist_ok=True)
+    (input_dir / "metadata").mkdir(parents=True, exist_ok=True)
+
+    def _write(path: Path, subjects: list[int]) -> None:
+        n = len(subjects) * 2
+        pl.DataFrame(
+            {
+                "subject_id": [s for s in subjects for _ in range(2)],
+                "time": [None] * n,
+                "code": ["A"] * n,
+                "numeric_value": [None] * n,
+            }
+        ).write_parquet(path)
+
+    _write(input_dir / "data" / "train" / "0.parquet", [1, 2, 3, 4])
+    _write(input_dir / "data" / "tuning" / "0.parquet", [5, 6])
+    _write(input_dir / "data" / "held_out" / "0.parquet", [7])
+
+    splits = pl.DataFrame(
+        {
+            "subject_id": [1, 2, 3, 4, 5, 6, 7],
+            "split": ["train"] * 4 + ["tuning"] * 2 + ["held_out"],
+        }
+    )
+    splits.write_parquet(input_dir / subject_splits_filepath)
+
+
+def test_reshard_to_split_runs_as_only_stage() -> None:
+    """``reshard_to_split`` as the sole stage in a pipeline produces correct sub-shards."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        input_dir = tmp / "input"
+        output_dir = tmp / "output"
+        _write_dataset(input_dir)
+
+        (tmp / "pipeline.yaml").write_text(
+            f"input_dir: {input_dir}\n"
+            f"output_dir: {output_dir}\n"
+            "stages:\n"
+            "  - reshard_to_split:\n"
+            "      n_subjects_per_shard: 2\n"
+        )
+
+        result = subprocess.run(
+            [
+                "MEDS_transform-stage",
+                str(tmp / "pipeline.yaml"),
+                "reshard_to_split",
+                "stage=reshard_to_split",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"Single-stage reshard failed:\n{result.stderr}\n{result.stdout}"
+
+        # When reshard_to_split is the only (final) stage, output lands in ``output_dir/data``.
+        shards_json = output_dir / "data" / ".shards.json"
+        assert shards_json.is_file()
+
+        import json
+
+        assignment = json.loads(shards_json.read_text())
+        assert set(assignment.keys()) == {"train/0", "train/1", "tuning/0", "held_out/0"}
+        # 4 train subjects split 2-2, 2 tuning in one shard, 1 held_out in one shard.
+        assert sorted(assignment["train/0"] + assignment["train/1"]) == [1, 2, 3, 4]
+        assert assignment["tuning/0"] == [5, 6]
+        assert assignment["held_out/0"] == [7]
+
+        # Every produced shard should be a valid parquet readable by polars.
+        for shard_name in assignment:
+            shard_fp = output_dir / "data" / f"{shard_name}.parquet"
+            df = pl.read_parquet(shard_fp)
+            assert df.height > 0, f"empty shard: {shard_fp}"
+            assert set(df["subject_id"].unique().to_list()) == set(assignment[shard_name])

--- a/tests/test_reshard_single_stage.py
+++ b/tests/test_reshard_single_stage.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 import polars as pl
-from meds import subject_splits_filepath
+from meds import DataSchema, subject_splits_filepath
 
 
 def _write_dataset(input_dir: Path) -> None:
@@ -20,16 +21,22 @@ def _write_dataset(input_dir: Path) -> None:
     (input_dir / "data" / "held_out").mkdir(parents=True, exist_ok=True)
     (input_dir / "metadata").mkdir(parents=True, exist_ok=True)
 
+    base_time = datetime(2020, 1, 1, tzinfo=UTC)
+
     def _write(path: Path, subjects: list[int]) -> None:
-        n = len(subjects) * 2
-        pl.DataFrame(
+        # Use a real timestamp column so reshard_to_split's sort by DataSchema.time_name
+        # hits a well-typed column, matching production MEDS data.
+        rows = [
             {
-                "subject_id": [s for s in subjects for _ in range(2)],
-                "time": [None] * n,
-                "code": ["A"] * n,
-                "numeric_value": [None] * n,
+                "subject_id": s,
+                "time": base_time.replace(day=1 + i),
+                "code": "A",
+                "numeric_value": None,
             }
-        ).write_parquet(path)
+            for s in subjects
+            for i in range(2)
+        ]
+        (pl.DataFrame(rows, schema_overrides={DataSchema.time_name: pl.Datetime("us")}).write_parquet(path))
 
     _write(input_dir / "data" / "train" / "0.parquet", [1, 2, 3, 4])
     _write(input_dir / "data" / "tuning" / "0.parquet", [5, 6])
@@ -82,9 +89,12 @@ def test_reshard_to_split_runs_as_only_stage() -> None:
         assignment = json.loads(shards_json.read_text())
         assert set(assignment.keys()) == {"train/0", "train/1", "tuning/0", "held_out/0"}
         # 4 train subjects split 2-2, 2 tuning in one shard, 1 held_out in one shard.
-        assert sorted(assignment["train/0"] + assignment["train/1"]) == [1, 2, 3, 4]
-        assert assignment["tuning/0"] == [5, 6]
-        assert assignment["held_out/0"] == [7]
+        # Compare as sets: the stage computes shard membership from parquet reads, so within-shard
+        # ordering is an implementation detail that shouldn't gate the regression test.
+        assert set(assignment["train/0"] + assignment["train/1"]) == {1, 2, 3, 4}
+        assert len(assignment["train/0"]) == 2 and len(assignment["train/1"]) == 2
+        assert set(assignment["tuning/0"]) == {5, 6}
+        assert set(assignment["held_out/0"]) == {7}
 
         # Every produced shard should be a valid parquet readable by polars.
         for shard_name in assignment:


### PR DESCRIPTION
## Summary

Closes #321. Verification that ``reshard_to_split`` runs correctly in single-stage mode, plus a regression test to prevent future breakage.

When I tried to reproduce the reported failure on current ``dev`` I could not. The stage runs cleanly whether invoked as the only stage in a pipeline (output → ``output_dir/data``) or as a non-final stage (output → ``output_dir/reshard_to_split``). My guess is the underlying issue was fixed incidentally by the mapreduce/test-infrastructure refactors (#275, #290) since the stub was filed.

This PR just adds a regression test covering:
- single-stage invocation via ``MEDS_transform-stage``
- multi-split input (train / tuning / held_out)
- verification of ``.shards.json`` contents
- verification of each produced parquet's contents

## Test plan

- [x] ``uv run pytest tests/test_reshard_single_stage.py``: passed.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)