### PR TITLE
Actionable error for aggregations that need object form (closes #164)

### DIFF
--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -170,11 +170,26 @@ VAL_PRESENT: pl.Expr = VAL.is_not_null() & VAL.is_not_nan()
 IS_INT: pl.Expr = VAL.round() == VAL
 PRESENT_VALS = VAL.filter(VAL_PRESENT)
 
-#: Aggregations that must be declared in object form with a specific required sub-key because their
-#: reducer takes parameters beyond the column selector. Maps aggregation name to the required extra
-#: key. Used by :func:`validate_args_and_get_code_cols` to raise a targeted error (issue #164).
-AGGREGATIONS_REQUIRING_OBJECT_FORM: dict[str, str] = {
-    MetadataFn.VALUES_QUANTILES.value: "quantiles",
+
+class _ObjectFormRequirement(NamedTuple):
+    """Schema for an aggregation whose reducer takes parameters beyond the column selector.
+
+    Attributes:
+        required_key: The name of the extra field the aggregation object must carry.
+        example_value: A syntactically valid example value for the required field (shown in errors).
+    """
+
+    required_key: str
+    example_value: str
+
+
+#: Aggregations that must be declared in object form. Maps aggregation name to its required-key
+#: contract. Used by :func:`validate_args_and_get_code_cols` to raise a targeted error (issue #164).
+#: Extend this dict when adding new parametrised aggregations.
+AGGREGATIONS_REQUIRING_OBJECT_FORM: dict[str, _ObjectFormRequirement] = {
+    MetadataFn.VALUES_QUANTILES.value: _ObjectFormRequirement(
+        required_key="quantiles", example_value="[0.25, 0.5, 0.75]"
+    ),
 }
 
 
@@ -230,6 +245,13 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
             code/n_subjects, code/n_occurrences, values/n_subjects, values/n_occurrences, values/n_ints,
             values/sum, values/sum_sqd, values/min, values/max, values/quantiles
 
+        Aggregation objects must carry an explicit ``name`` field:
+
+        >>> validate_args_and_get_code_cols(DictConfig({"aggregations": [{"quantiles": [0.5]}]}), None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation object is missing a 'name' field. Got: {'quantiles': [0.5]}.
+
         Aggregations such as ``values/quantiles`` require the object form with a specific field. The
         validator raises an actionable error pointing at the missing key:
 
@@ -275,8 +297,10 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
     aggregations = stage_cfg.aggregations
     for agg in aggregations:
         if isinstance(agg, dict | DictConfig):
-            agg_name = agg.get("name", None)
             agg_obj = agg
+            if "name" not in agg_obj or agg_obj.get("name") in (None, ""):
+                raise ValueError(f"Aggregation object is missing a 'name' field. Got: {dict(agg_obj)}.")
+            agg_name = agg_obj["name"]
         else:
             agg_name = agg
             agg_obj = None
@@ -286,22 +310,22 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
                 f"are: {', '.join([fn.value for fn in MetadataFn])}"
             )
         if agg_name in AGGREGATIONS_REQUIRING_OBJECT_FORM:
-            required_key = AGGREGATIONS_REQUIRING_OBJECT_FORM[agg_name]
+            required = AGGREGATIONS_REQUIRING_OBJECT_FORM[agg_name]
             if agg_obj is None:
                 raise ValueError(
-                    f"Aggregation '{agg_name}' requires object form with a '{required_key}' field. "
-                    f"Got it as a plain string.\nExample:\n"
+                    f"Aggregation '{agg_name}' requires object form with a '{required.required_key}' "
+                    f"field. Got it as a plain string.\nExample:\n"
                     f"  aggregations:\n"
                     f"    - name: {agg_name}\n"
-                    f"      {required_key}: [0.25, 0.5, 0.75]"
+                    f"      {required.required_key}: {required.example_value}"
                 )
-            if required_key not in agg_obj:
+            if required.required_key not in agg_obj:
                 raise ValueError(
-                    f"Aggregation '{agg_name}' is missing the required '{required_key}' field. "
-                    f"Got: {dict(agg_obj)}.\nExample:\n"
+                    f"Aggregation '{agg_name}' is missing the required '{required.required_key}' "
+                    f"field. Got: {dict(agg_obj)}.\nExample:\n"
                     f"  aggregations:\n"
                     f"    - name: {agg_name}\n"
-                    f"      {required_key}: [0.25, 0.5, 0.75]"
+                    f"      {required.required_key}: {required.example_value}"
                 )
 
     match code_modifiers:

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -170,6 +170,14 @@ VAL_PRESENT: pl.Expr = VAL.is_not_null() & VAL.is_not_nan()
 IS_INT: pl.Expr = VAL.round() == VAL
 PRESENT_VALS = VAL.filter(VAL_PRESENT)
 
+#: Aggregations that must be declared in object form with a specific required sub-key because their
+#: reducer takes parameters beyond the column selector. Maps aggregation name to the required extra
+#: key. Used by :func:`validate_args_and_get_code_cols` to raise a targeted error (issue #164).
+AGGREGATIONS_REQUIRING_OBJECT_FORM: dict[str, str] = {
+    MetadataFn.VALUES_QUANTILES.value: "quantiles",
+}
+
+
 CODE_METADATA_AGGREGATIONS: dict[MetadataFn, MapReducePair] = {
     MetadataFn.CODE_N_PATIENTS: MapReducePair(
         pl.col(DataSchema.subject_id_name).n_unique(), pl.sum_horizontal
@@ -221,6 +229,29 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
         ValueError: Metadata aggregation function INVALID not found in MetadataFn enumeration. Values are:
             code/n_subjects, code/n_occurrences, values/n_subjects, values/n_occurrences, values/n_ints,
             values/sum, values/sum_sqd, values/min, values/max, values/quantiles
+
+        Aggregations such as ``values/quantiles`` require the object form with a specific field. The
+        validator raises an actionable error pointing at the missing key:
+
+        >>> validate_args_and_get_code_cols(DictConfig({"aggregations": ["values/quantiles"]}), None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' requires object form with a 'quantiles' field. Got it
+        as a plain string.
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
+        >>> cfg = DictConfig({"aggregations": [{"name": "values/quantiles"}]})
+        >>> validate_args_and_get_code_cols(cfg, None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' is missing the required 'quantiles' field. Got:
+        {'name': 'values/quantiles'}.
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
         >>> valid_cfg = DictConfig({"aggregations": ["code/n_subjects", {"name": "values/n_ints"}]})
         >>> validate_args_and_get_code_cols(valid_cfg, 33)
         Traceback (most recent call last):
@@ -244,12 +275,34 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
     aggregations = stage_cfg.aggregations
     for agg in aggregations:
         if isinstance(agg, dict | DictConfig):
-            agg = agg.get("name", None)
-        if agg not in {fn.value for fn in MetadataFn}:
+            agg_name = agg.get("name", None)
+            agg_obj = agg
+        else:
+            agg_name = agg
+            agg_obj = None
+        if agg_name not in {fn.value for fn in MetadataFn}:
             raise ValueError(
-                f"Metadata aggregation function {agg} not found in MetadataFn enumeration. Values are: "
-                f"{', '.join([fn.value for fn in MetadataFn])}"
+                f"Metadata aggregation function {agg_name} not found in MetadataFn enumeration. Values "
+                f"are: {', '.join([fn.value for fn in MetadataFn])}"
             )
+        if agg_name in AGGREGATIONS_REQUIRING_OBJECT_FORM:
+            required_key = AGGREGATIONS_REQUIRING_OBJECT_FORM[agg_name]
+            if agg_obj is None:
+                raise ValueError(
+                    f"Aggregation '{agg_name}' requires object form with a '{required_key}' field. "
+                    f"Got it as a plain string.\nExample:\n"
+                    f"  aggregations:\n"
+                    f"    - name: {agg_name}\n"
+                    f"      {required_key}: [0.25, 0.5, 0.75]"
+                )
+            if required_key not in agg_obj:
+                raise ValueError(
+                    f"Aggregation '{agg_name}' is missing the required '{required_key}' field. "
+                    f"Got: {dict(agg_obj)}.\nExample:\n"
+                    f"  aggregations:\n"
+                    f"    - name: {agg_name}\n"
+                    f"      {required_key}: [0.25, 0.5, 0.75]"
+                )
 
     match code_modifiers:
         case None:

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -186,7 +186,16 @@ def _validate_quantiles(value: object) -> str | None:
 
 
 def _validate_non_null(value: object) -> str | None:
-    """Default ``_ObjectFormRequirement.validator``: rejects only ``None``."""
+    """Default ``_ObjectFormRequirement.validator``: rejects only ``None``.
+
+    Examples:
+        >>> _validate_non_null("anything") is None
+        True
+        >>> _validate_non_null(0) is None
+        True
+        >>> _validate_non_null(None)
+        'must not be null'
+    """
     return None if value is not None else "must not be null"
 
 

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -185,6 +185,11 @@ def _validate_quantiles(value: object) -> str | None:
     return None
 
 
+def _validate_non_null(value: object) -> str | None:
+    """Default ``_ObjectFormRequirement.validator``: rejects only ``None``."""
+    return None if value is not None else "must not be null"
+
+
 class _ObjectFormRequirement(NamedTuple):
     """Schema for an aggregation whose reducer takes parameters beyond the column selector.
 
@@ -197,7 +202,7 @@ class _ObjectFormRequirement(NamedTuple):
 
     required_key: str
     example_value: str
-    validator: Callable[[object], str | None] = lambda v: None if v is not None else "must not be null"
+    validator: Callable[[object], str | None] = _validate_non_null
 
 
 #: Aggregations that must be declared in object form. Maps aggregation name to its required-key

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -328,6 +328,16 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
           aggregations:
             - name: values/quantiles
               quantiles: [0.25, 0.5, 0.75]
+        >>> cfg = DictConfig({"aggregations": [{"name": "values/quantiles", "quantiles": ["oops"]}]})
+        >>> validate_args_and_get_code_cols(cfg, None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' has an invalid 'quantiles' value: each entry must
+        be a number; got str ('oops').
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
         >>> valid_cfg = DictConfig({"aggregations": ["code/n_subjects", {"name": "values/n_ints"}]})
         >>> validate_args_and_get_code_cols(valid_cfg, 33)
         Traceback (most recent call last):

--- a/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
+++ b/src/MEDS_transforms/stages/aggregate_code_metadata/aggregate_code_metadata.py
@@ -171,16 +171,33 @@ IS_INT: pl.Expr = VAL.round() == VAL
 PRESENT_VALS = VAL.filter(VAL_PRESENT)
 
 
+def _validate_quantiles(value: object) -> str | None:
+    """Return an error message if ``value`` isn't a non-empty sequence of floats in (0, 1)."""
+    if not isinstance(value, (list, tuple, ListConfig)):
+        return f"must be a list of numbers; got {type(value).__name__} ({value!r})"
+    if len(value) == 0:
+        return "must be non-empty"
+    for q in value:
+        if not isinstance(q, (int, float)) or isinstance(q, bool):
+            return f"each entry must be a number; got {type(q).__name__} ({q!r})"
+        if not (0 < float(q) < 1):
+            return f"each entry must satisfy 0 < q < 1; got {q!r}"
+    return None
+
+
 class _ObjectFormRequirement(NamedTuple):
     """Schema for an aggregation whose reducer takes parameters beyond the column selector.
 
     Attributes:
         required_key: The name of the extra field the aggregation object must carry.
         example_value: A syntactically valid example value for the required field (shown in errors).
+        validator: Callable that returns a human-readable error string when the supplied value is
+            invalid, or ``None`` when the value is acceptable. Default: reject ``None`` only.
     """
 
     required_key: str
     example_value: str
+    validator: Callable[[object], str | None] = lambda v: None if v is not None else "must not be null"
 
 
 #: Aggregations that must be declared in object form. Maps aggregation name to its required-key
@@ -188,7 +205,9 @@ class _ObjectFormRequirement(NamedTuple):
 #: Extend this dict when adding new parametrised aggregations.
 AGGREGATIONS_REQUIRING_OBJECT_FORM: dict[str, _ObjectFormRequirement] = {
     MetadataFn.VALUES_QUANTILES.value: _ObjectFormRequirement(
-        required_key="quantiles", example_value="[0.25, 0.5, 0.75]"
+        required_key="quantiles",
+        example_value="[0.25, 0.5, 0.75]",
+        validator=_validate_quantiles,
     ),
 }
 
@@ -258,8 +277,8 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
         >>> validate_args_and_get_code_cols(DictConfig({"aggregations": ["values/quantiles"]}), None)
         Traceback (most recent call last):
             ...
-        ValueError: Aggregation 'values/quantiles' requires object form with a 'quantiles' field. Got it
-        as a plain string.
+        ValueError: Aggregation 'values/quantiles' requires object form with a 'quantiles' field.
+        Got it as a plain string.
         Example:
           aggregations:
             - name: values/quantiles
@@ -268,8 +287,43 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
         >>> validate_args_and_get_code_cols(cfg, None)
         Traceback (most recent call last):
             ...
-        ValueError: Aggregation 'values/quantiles' is missing the required 'quantiles' field. Got:
-        {'name': 'values/quantiles'}.
+        ValueError: Aggregation 'values/quantiles' is missing the required 'quantiles' field.
+        Got:
+          {'name': 'values/quantiles'}
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
+
+        The required field's value is also checked for its expected shape. For ``quantiles``,
+        this must be a non-empty list of floats in ``(0, 1)``:
+
+        >>> cfg = DictConfig({"aggregations": [{"name": "values/quantiles", "quantiles": None}]})
+        >>> validate_args_and_get_code_cols(cfg, None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' has an invalid 'quantiles' value: must be a list
+        of numbers; got NoneType (None).
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
+        >>> cfg = DictConfig({"aggregations": [{"name": "values/quantiles", "quantiles": []}]})
+        >>> validate_args_and_get_code_cols(cfg, None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' has an invalid 'quantiles' value: must be
+        non-empty.
+        Example:
+          aggregations:
+            - name: values/quantiles
+              quantiles: [0.25, 0.5, 0.75]
+        >>> cfg = DictConfig({"aggregations": [{"name": "values/quantiles", "quantiles": [1.5]}]})
+        >>> validate_args_and_get_code_cols(cfg, None)
+        Traceback (most recent call last):
+            ...
+        ValueError: Aggregation 'values/quantiles' has an invalid 'quantiles' value: each entry must
+        satisfy 0 < q < 1; got 1.5.
         Example:
           aggregations:
             - name: values/quantiles
@@ -311,21 +365,27 @@ def validate_args_and_get_code_cols(stage_cfg: DictConfig, code_modifiers: list[
             )
         if agg_name in AGGREGATIONS_REQUIRING_OBJECT_FORM:
             required = AGGREGATIONS_REQUIRING_OBJECT_FORM[agg_name]
+            example_block = (
+                "Example:\n"
+                "  aggregations:\n"
+                f"    - name: {agg_name}\n"
+                f"      {required.required_key}: {required.example_value}"
+            )
             if agg_obj is None:
                 raise ValueError(
                     f"Aggregation '{agg_name}' requires object form with a '{required.required_key}' "
-                    f"field. Got it as a plain string.\nExample:\n"
-                    f"  aggregations:\n"
-                    f"    - name: {agg_name}\n"
-                    f"      {required.required_key}: {required.example_value}"
+                    f"field.\nGot it as a plain string.\n{example_block}"
                 )
             if required.required_key not in agg_obj:
                 raise ValueError(
                     f"Aggregation '{agg_name}' is missing the required '{required.required_key}' "
-                    f"field. Got: {dict(agg_obj)}.\nExample:\n"
-                    f"  aggregations:\n"
-                    f"    - name: {agg_name}\n"
-                    f"      {required.required_key}: {required.example_value}"
+                    f"field.\nGot:\n  {dict(agg_obj)}\n{example_block}"
+                )
+            validator_err = required.validator(agg_obj[required.required_key])
+            if validator_err is not None:
+                raise ValueError(
+                    f"Aggregation '{agg_name}' has an invalid '{required.required_key}' value: "
+                    f"{validator_err}.\n{example_block}"
                 )
 
     match code_modifiers:


### PR DESCRIPTION
## Summary

Closes #164. Aggregations whose reducer needs extra parameters (today that is only ``values/quantiles`` needing ``quantiles: [...]``) used to fail with a cryptic ``TypeError`` from the reducer when misconfigured as a plain string. The validator now raises a targeted ``ValueError`` that names the aggregation, the missing key, and shows the correct YAML shape.

```
ValueError: Aggregation 'values/quantiles' requires object form with a 'quantiles' field.
Got it as a plain string.
Example:
  aggregations:
    - name: values/quantiles
      quantiles: [0.25, 0.5, 0.75]
```

The registry (``AGGREGATIONS_REQUIRING_OBJECT_FORM``) is a simple ``dict`` so new parametrized aggregations can be added to it as the stage grows.

## Test plan

- [x] New doctests covering both the plain-string and object-missing-key failure modes.
- [x] Full non-parallel suite passes.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)