### PR TITLE
List pipeline-level config keys in CLI help (closes #320)

### DIFF
--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -16,31 +16,10 @@ HELP_STRS = {"--help", "-h", "help", "h"}
 MAIN_CFG_PATH = files(__package_name__) / "configs" / "_main.yaml"
 
 
-#: Pipeline-level configuration keys consumed by the runner rather than individual stages. Surfaced
-#: in CLI help so users know what is accepted via ``--overrides`` or at the top level of a pipeline
-#: YAML.
-PIPELINE_CONFIG_KEYS: dict[str, str] = {
-    "input_dir": "Root MEDS directory to read from (contains `data/` and `metadata/`).",
-    "output_dir": "Root directory to write stage outputs into.",
-    "stages": "List of stage configs defining the pipeline (see each stage's docs).",
-    "description": "Optional free-text pipeline description.",
-    "parallelize.n_workers": "Number of parallel workers to launch per stage (default 1).",
-    "parallelize.launcher": "Hydra launcher to use (e.g. 'joblib', 'slurm').",
-    "parallelize.launcher_params": "Launcher-specific keyword arguments forwarded to Hydra.",
-}
-
-
-def _pipeline_keys_help_block() -> str:
-    """Return a stable help-text block listing pipeline-level config keys."""
-    lines = ["Pipeline-level configuration keys (settable via pipeline YAML or `--overrides`):"]
-    width = max(len(k) for k in PIPELINE_CONFIG_KEYS)
-    for key, desc in PIPELINE_CONFIG_KEYS.items():
-        lines.append(f"  {key.ljust(width)}  {desc}")
-    return "\n".join(lines)
-
-
 def print_help_stage():
     """Print help for all stages."""
+
+    from ._cli_help import pipeline_keys_help_block
 
     all_stage_names = list(get_all_registered_stages().keys())
 
@@ -55,7 +34,7 @@ def print_help_stage():
     for name in sorted(all_stage_names):
         print(f"  - {name}")
     print()
-    print(_pipeline_keys_help_block())
+    print(pipeline_keys_help_block())
 
 
 def run_stage():  # pragma: no cover

--- a/src/MEDS_transforms/__main__.py
+++ b/src/MEDS_transforms/__main__.py
@@ -16,6 +16,29 @@ HELP_STRS = {"--help", "-h", "help", "h"}
 MAIN_CFG_PATH = files(__package_name__) / "configs" / "_main.yaml"
 
 
+#: Pipeline-level configuration keys consumed by the runner rather than individual stages. Surfaced
+#: in CLI help so users know what is accepted via ``--overrides`` or at the top level of a pipeline
+#: YAML.
+PIPELINE_CONFIG_KEYS: dict[str, str] = {
+    "input_dir": "Root MEDS directory to read from (contains `data/` and `metadata/`).",
+    "output_dir": "Root directory to write stage outputs into.",
+    "stages": "List of stage configs defining the pipeline (see each stage's docs).",
+    "description": "Optional free-text pipeline description.",
+    "parallelize.n_workers": "Number of parallel workers to launch per stage (default 1).",
+    "parallelize.launcher": "Hydra launcher to use (e.g. 'joblib', 'slurm').",
+    "parallelize.launcher_params": "Launcher-specific keyword arguments forwarded to Hydra.",
+}
+
+
+def _pipeline_keys_help_block() -> str:
+    """Return a stable help-text block listing pipeline-level config keys."""
+    lines = ["Pipeline-level configuration keys (settable via pipeline YAML or `--overrides`):"]
+    width = max(len(k) for k in PIPELINE_CONFIG_KEYS)
+    for key, desc in PIPELINE_CONFIG_KEYS.items():
+        lines.append(f"  {key.ljust(width)}  {desc}")
+    return "\n".join(lines)
+
+
 def print_help_stage():
     """Print help for all stages."""
 
@@ -31,6 +54,8 @@ def print_help_stage():
     print("Available stages:")
     for name in sorted(all_stage_names):
         print(f"  - {name}")
+    print()
+    print(_pipeline_keys_help_block())
 
 
 def run_stage():  # pragma: no cover

--- a/src/MEDS_transforms/_cli_help.py
+++ b/src/MEDS_transforms/_cli_help.py
@@ -7,8 +7,7 @@ Kept as a small, dependency-light module so ``runner.main()`` can format its
 from __future__ import annotations
 
 #: Pipeline-level configuration keys consumed by the runner rather than individual stages. Surfaced
-#: in CLI help so users know what is accepted via ``--overrides`` or at the top level of a pipeline
-#: YAML.
+#: in CLI help so users know what is accepted in a pipeline YAML and via Hydra-style CLI overrides.
 PIPELINE_CONFIG_KEYS: dict[str, str] = {
     "input_dir": "Root MEDS directory to read from (contains `data/` and `metadata/`).",
     "output_dir": "Root directory to write stage outputs into.",
@@ -29,8 +28,14 @@ def pipeline_keys_help_block() -> str:
         True
         >>> "parallelize.n_workers" in block
         True
+        >>> "MEDS_transform-pipeline" in block
+        True
     """
-    lines = ["Pipeline-level configuration keys (settable via pipeline YAML or `--overrides`):"]
+    header = (
+        "Pipeline-level configuration keys (settable in the pipeline YAML; `--overrides` is "
+        "accepted by `MEDS_transform-pipeline`):"
+    )
+    lines = [header]
     width = max(len(k) for k in PIPELINE_CONFIG_KEYS)
     for key, desc in PIPELINE_CONFIG_KEYS.items():
         lines.append(f"  {key.ljust(width)}  {desc}")

--- a/src/MEDS_transforms/_cli_help.py
+++ b/src/MEDS_transforms/_cli_help.py
@@ -1,0 +1,37 @@
+"""Shared CLI help text for the pipeline runner and stage dispatcher.
+
+Kept as a small, dependency-light module so ``runner.main()`` can format its
+``argparse`` epilog without pulling Hydra through ``__main__``.
+"""
+
+from __future__ import annotations
+
+#: Pipeline-level configuration keys consumed by the runner rather than individual stages. Surfaced
+#: in CLI help so users know what is accepted via ``--overrides`` or at the top level of a pipeline
+#: YAML.
+PIPELINE_CONFIG_KEYS: dict[str, str] = {
+    "input_dir": "Root MEDS directory to read from (contains `data/` and `metadata/`).",
+    "output_dir": "Root directory to write stage outputs into.",
+    "stages": "List of stage configs defining the pipeline (see each stage's docs).",
+    "description": "Optional free-text pipeline description.",
+    "parallelize.n_workers": "Number of parallel workers to launch per stage (default 1).",
+    "parallelize.launcher": "Hydra launcher to use (e.g. 'joblib', 'slurm').",
+    "parallelize.launcher_params": "Launcher-specific keyword arguments forwarded to Hydra.",
+}
+
+
+def pipeline_keys_help_block() -> str:
+    """Return a stable help-text block listing pipeline-level config keys.
+
+    Examples:
+        >>> block = pipeline_keys_help_block()
+        >>> block.startswith("Pipeline-level configuration keys")
+        True
+        >>> "parallelize.n_workers" in block
+        True
+    """
+    lines = ["Pipeline-level configuration keys (settable via pipeline YAML or `--overrides`):"]
+    width = max(len(k) for k in PIPELINE_CONFIG_KEYS)
+    for key, desc in PIPELINE_CONFIG_KEYS.items():
+        lines.append(f"  {key.ljust(width)}  {desc}")
+    return "\n".join(lines)

--- a/src/MEDS_transforms/_cli_help.py
+++ b/src/MEDS_transforms/_cli_help.py
@@ -22,6 +22,10 @@ PIPELINE_CONFIG_KEYS: dict[str, str] = {
 def pipeline_keys_help_block() -> str:
     """Return a stable help-text block listing pipeline-level config keys.
 
+    Dot-notation keys (e.g. ``parallelize.n_workers``) show the Hydra override path — that form
+    works directly with ``MEDS_transform-pipeline --overrides``. In pipeline YAML, the same key
+    is written as a nested mapping (``parallelize:`` with ``n_workers:`` indented beneath).
+
     Examples:
         >>> block = pipeline_keys_help_block()
         >>> block.startswith("Pipeline-level configuration keys")
@@ -30,10 +34,13 @@ def pipeline_keys_help_block() -> str:
         True
         >>> "MEDS_transform-pipeline" in block
         True
+        >>> "nested" in block
+        True
     """
     header = (
-        "Pipeline-level configuration keys (settable in the pipeline YAML; `--overrides` is "
-        "accepted by `MEDS_transform-pipeline`):"
+        "Pipeline-level configuration keys (dot-notation is the Hydra override path accepted by "
+        "`MEDS_transform-pipeline --overrides`; in a pipeline YAML, write these as nested "
+        "mappings — e.g. `parallelize:` with `n_workers:` indented):"
     )
     lines = [header]
     width = max(len(k) for k in PIPELINE_CONFIG_KEYS)

--- a/src/MEDS_transforms/_cli_help.py
+++ b/src/MEDS_transforms/_cli_help.py
@@ -27,22 +27,24 @@ def pipeline_keys_help_block() -> str:
     is written as a nested mapping (``parallelize:`` with ``n_workers:`` indented beneath).
 
     Examples:
-        >>> block = pipeline_keys_help_block()
-        >>> block.startswith("Pipeline-level configuration keys")
-        True
-        >>> "parallelize.n_workers" in block
-        True
-        >>> "MEDS_transform-pipeline" in block
-        True
-        >>> "nested" in block
-        True
+        >>> print(pipeline_keys_help_block())
+        Pipeline-level configuration keys (dot-notation is the Hydra override path accepted by
+        `MEDS_transform-pipeline --overrides`; in a pipeline YAML, write these as nested mappings
+        — e.g. `parallelize:` with `n_workers:` indented):
+          input_dir                    Root MEDS directory to read from (contains `data/` and `metadata/`).
+          output_dir                   Root directory to write stage outputs into.
+          stages                       List of stage configs defining the pipeline (see each stage's docs).
+          description                  Optional free-text pipeline description.
+          parallelize.n_workers        Number of parallel workers to launch per stage (default 1).
+          parallelize.launcher         Hydra launcher to use (e.g. 'joblib', 'slurm').
+          parallelize.launcher_params  Launcher-specific keyword arguments forwarded to Hydra.
     """
-    header = (
-        "Pipeline-level configuration keys (dot-notation is the Hydra override path accepted by "
-        "`MEDS_transform-pipeline --overrides`; in a pipeline YAML, write these as nested "
-        "mappings — e.g. `parallelize:` with `n_workers:` indented):"
-    )
-    lines = [header]
+    header_lines = [
+        "Pipeline-level configuration keys (dot-notation is the Hydra override path accepted by",
+        "`MEDS_transform-pipeline --overrides`; in a pipeline YAML, write these as nested mappings",
+        "— e.g. `parallelize:` with `n_workers:` indented):",
+    ]
+    lines = list(header_lines)
     width = max(len(k) for k in PIPELINE_CONFIG_KEYS)
     for key, desc in PIPELINE_CONFIG_KEYS.items():
         lines.append(f"  {key.ljust(width)}  {desc}")

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -279,7 +279,14 @@ def run_stage(
 def main(argv: list[str] | None = None) -> int:  # pragma: no cover
     """Run an entire pipeline based on command line arguments."""
 
-    parser = argparse.ArgumentParser(description="MEDS-Transforms Pipeline Runner")
+    # Lazy import to avoid a cycle if __main__ imports runner.
+    from .__main__ import _pipeline_keys_help_block
+
+    parser = argparse.ArgumentParser(
+        description="MEDS-Transforms Pipeline Runner",
+        epilog=_pipeline_keys_help_block(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "pipeline_config_fp",
         help="Path to the pipeline configuration file, either as a raw path or with pkg:// syntax.",

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -279,12 +279,11 @@ def run_stage(
 def main(argv: list[str] | None = None) -> int:  # pragma: no cover
     """Run an entire pipeline based on command line arguments."""
 
-    # Lazy import to avoid a cycle if __main__ imports runner.
-    from .__main__ import _pipeline_keys_help_block
+    from ._cli_help import pipeline_keys_help_block
 
     parser = argparse.ArgumentParser(
         description="MEDS-Transforms Pipeline Runner",
-        epilog=_pipeline_keys_help_block(),
+        epilog=pipeline_keys_help_block(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -145,6 +145,18 @@ def test_pipeline_help():
     help_text = out.stdout.decode("utf-8")
     assert "usage:" in help_text.lower()
     assert "pipeline_config_fp" in help_text
+    # Pipeline-level config keys should be surfaced in the epilog (see #320).
+    assert "Pipeline-level configuration keys" in help_text
+    assert "parallelize.n_workers" in help_text
+    assert "input_dir" in help_text
+
+
+def test_stage_help_lists_pipeline_keys():
+    """``MEDS_transform-stage -h`` should also surface pipeline-level config keys (see #320)."""
+    out = subprocess.run("MEDS_transform-stage -h", shell=True, check=True, capture_output=True)
+    help_text = out.stdout.decode("utf-8")
+    assert "Pipeline-level configuration keys" in help_text
+    assert "parallelize.n_workers" in help_text
 
 
 def test_pipeline_runner_with_done_file():


### PR DESCRIPTION
## Summary

Closes #320. Users had no way to discover pipeline-level keys (``input_dir``, ``output_dir``, ``parallelize.*``, ``stages``, ``description``) from ``-h``; they had to grep ``runner.py``.

Both CLIs now append the same table after their usage:

```
Pipeline-level configuration keys (settable in the pipeline YAML; `--overrides` is accepted by `MEDS_transform-pipeline`):
  input_dir                    Root MEDS directory to read from ...
  output_dir                   Root directory to write stage outputs into.
  stages                       List of stage configs defining the pipeline ...
  description                  Optional free-text pipeline description.
  parallelize.n_workers        Number of parallel workers to launch per stage (default 1).
  parallelize.launcher         Hydra launcher to use (e.g. 'joblib', 'slurm').
  parallelize.launcher_params  Launcher-specific keyword arguments forwarded to Hydra.
```

The table is defined once in ``src/MEDS_transforms/_cli_help.py`` (``PIPELINE_CONFIG_KEYS``) and consumed by both entrypoints. ``runner.main()`` imports only ``_cli_help`` so the pipeline runner's help path stays free of the Hydra/ConfigStore imports that ``__main__`` pulls in.

## Test plan

- [x] Manual: ``MEDS_transform-pipeline -h`` and ``MEDS_transform-stage -h`` both show the new block.
- [x] ``test_pipeline_help`` extended and new ``test_stage_help_lists_pipeline_keys`` asserts the block.
- [x] Full non-parallel suite passes.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)