### PR TITLE
Add StageExample.render_content hook for docgen (closes #383)

### DIFF
--- a/example/simple_example_pkg/src/simple_example_pkg/export_code_summary/export_code_summary.py
+++ b/example/simple_example_pkg/src/simple_example_pkg/export_code_summary/export_code_summary.py
@@ -139,7 +139,10 @@ class JsonOutputStageExample(StageExample):
                     lines.append(df_to_markdown(DataFrame(rows)))
                     lines.append("")
 
-        cmd = f"MEDS_transform-stage <pipeline.yaml> {self.stage_name} input_dir=<input> output_dir=<output>"
+        cmd = f"MEDS_transform-stage <pipeline.yaml> {self.stage_name}"
+        if self.cmd_args:
+            cmd += " " + " ".join(self.cmd_args)
+        cmd += " input_dir=<input> output_dir=<output>"
         lines.extend(["**Run this stage:**", "", "```bash", cmd, "```", ""])
 
         return lines

--- a/example/simple_example_pkg/src/simple_example_pkg/export_code_summary/export_code_summary.py
+++ b/example/simple_example_pkg/src/simple_example_pkg/export_code_summary/export_code_summary.py
@@ -101,6 +101,49 @@ class JsonOutputStageExample(StageExample):
                         f"Content mismatch in {rel}:\n  Expected: {expected_text}\n  Got: {actual_text}"
                     )
 
+    def render_content(self, example_dir=None):
+        """Render the example with JSON output parsed into a Markdown table.
+
+        Demonstrates the ``StageExample.render_content`` extension hook. The base class's default
+        ``Path`` handling would render ``want_data`` as a generic YAML code block; this override
+        materializes the spec, parses each ``.json`` file into rows, and emits a table for each —
+        which is friendlier for readers than raw YAML.
+
+        Subclasses like this one own the full rendering of their example sections; they call
+        shared helpers from :mod:`MEDS_transforms.stages.docgen` for table formatting.
+        """
+        from omegaconf import OmegaConf
+        from polars import DataFrame
+
+        from MEDS_transforms.stages.docgen import df_to_markdown, read_example_readme
+
+        lines: list[str] = []
+
+        example_readme = read_example_readme(example_dir)
+        if example_readme:
+            lines.extend([example_readme, ""])
+
+        if self.stage_cfg:
+            cfg_str = OmegaConf.to_yaml(OmegaConf.create(self.stage_cfg)).strip()
+            lines.extend(["**Stage configuration:**", "", "```yaml", cfg_str, "```", ""])
+
+        if self.want_data is not None:
+            with tempfile.TemporaryDirectory() as expected_root:
+                expected_root = Path(expected_root)
+                yaml_disk(self.want_data, root_dir=expected_root)
+                for fp in sorted(expected_root.rglob("*.json")):
+                    rel = fp.relative_to(expected_root)
+                    obj = json.loads(fp.read_text())
+                    rows = [{"key": k, "value": v} for k, v in sorted(obj.items())]
+                    lines.extend([f"**Expected `{rel}`:**", ""])
+                    lines.append(df_to_markdown(DataFrame(rows)))
+                    lines.append("")
+
+        cmd = f"MEDS_transform-stage <pipeline.yaml> {self.stage_name} input_dir=<input> output_dir=<output>"
+        lines.extend(["**Run this stage:**", "", "```bash", cmd, "```", ""])
+
+        return lines
+
 
 @Stage.register(is_metadata=False, example_class=JsonOutputStageExample)
 def main(cfg: DictConfig):

--- a/example/simple_example_pkg/tests/test_registered_stages.py
+++ b/example/simple_example_pkg/tests/test_registered_stages.py
@@ -1,7 +1,30 @@
 """This file will use the automated stage example definitions to test each defined stage in this package."""
 
+from pathlib import Path
+
 from MEDS_transforms.stages import StageExample
+from MEDS_transforms.stages.docgen import generate_stage_docs
 
 
 def test_stage_scenario(stage_example: StageExample):
     stage_example.test()
+
+
+def test_docgen_renders_custom_example_class():
+    """``generate_stage_docs`` must walk stages whose ``StageExample`` subclass owns rendering.
+
+    ``export_code_summary`` registers with a ``JsonOutputStageExample`` subclass whose
+    ``want_data`` is a ``Path`` to a ``yaml_to_disk`` spec. The subclass overrides
+    ``render_content`` to materialize the spec and render each JSON file as a Markdown table.
+    This validates the hook end-to-end: if the base class's hard-coded ``_pl_shards`` assumption
+    were still in place, this call would raise ``AttributeError``.
+    """
+
+    pkg_root = Path(__file__).resolve().parents[1]
+    docs = {doc.stage_name: doc for doc in generate_stage_docs("simple_example_pkg", root=pkg_root)}
+
+    export = docs["export_code_summary"]
+    assert "**Expected `code_summary.json`:**" in export.content
+    assert "| ADMISSION//CARDIAC | 2 |" in export.content
+    # The base-class ``_pl_shards``-based renderer would have produced this heading.
+    assert "**Expected output data:**" not in export.content

--- a/src/MEDS_transforms/stages/docgen.py
+++ b/src/MEDS_transforms/stages/docgen.py
@@ -48,10 +48,10 @@ class StageDoc:
 
 
 def read_example_readme(directory: Path | None) -> str | None:
-    """Read a README.md from *directory*, stripping any leading ``#`` heading.
+    """Read a README.md from *directory*, stripping any leading ATX heading.
 
     The leading heading is removed because the README content is embedded under an existing section heading in
-    the generated page.
+    the generated page. Any ATX level is stripped (``#``, ``##``, ``###``, ...).
 
     Exposed publicly so :class:`StageExample` subclass overrides of
     :meth:`~StageExample.render_content` can reuse the same preamble behavior.
@@ -66,6 +66,10 @@ def read_example_readme(directory: Path | None) -> str | None:
         ...     read_example_readme(Path(d))
         'Body text.'
         >>> with tempfile.TemporaryDirectory() as d:
+        ...     _ = (Path(d) / "README.md").write_text("### Deep Heading\\n\\nDeep body.\\n")
+        ...     read_example_readme(Path(d))
+        'Deep body.'
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     read_example_readme(Path(d)) is None
         True
     """
@@ -76,8 +80,8 @@ def read_example_readme(directory: Path | None) -> str | None:
     if not readme.is_file():
         return None
     text = readme.read_text().strip()
-    # Strip a leading ATX heading (e.g. "# Title\n\n...") to avoid duplicate/conflicting headings.
-    text = re.sub(r"^#[^\n]*\n+", "", text).strip()
+    # Strip a leading ATX heading (``# Title``, ``## Sub``, etc.) to avoid duplicate/conflicting headings.
+    text = re.sub(r"^#+[^\n]*\n+", "", text).strip()
     return text or None
 
 

--- a/src/MEDS_transforms/stages/docgen.py
+++ b/src/MEDS_transforms/stages/docgen.py
@@ -2,6 +2,10 @@
 
 This helper builds a ``StageDoc`` for each registered stage so it can be
 rendered in the documentation site.
+
+Per-example rendering is delegated to :meth:`StageExample.render_content`, so downstream packages
+that subclass :class:`StageExample` for non-MEDS-shaped output (JSON, CSV, etc.) can override the
+rendering without monkey-patching this module. See the default implementation there.
 """
 
 from __future__ import annotations
@@ -43,23 +47,26 @@ class StageDoc:
     edit_path: Path | None = None
 
 
-def _read_readme(directory: Path | None) -> str | None:
+def read_example_readme(directory: Path | None) -> str | None:
     """Read a README.md from *directory*, stripping any leading ``#`` heading.
 
     The leading heading is removed because the README content is embedded under an existing section heading in
     the generated page.
 
+    Exposed publicly so :class:`StageExample` subclass overrides of
+    :meth:`~StageExample.render_content` can reuse the same preamble behavior.
+
     Examples:
-        >>> _read_readme(None) is None
+        >>> read_example_readme(None) is None
         True
         >>> import tempfile
         >>> from pathlib import Path
         >>> with tempfile.TemporaryDirectory() as d:
         ...     _ = (Path(d) / "README.md").write_text("# Title\\n\\nBody text.\\n")
-        ...     _read_readme(Path(d))
+        ...     read_example_readme(Path(d))
         'Body text.'
         >>> with tempfile.TemporaryDirectory() as d:
-        ...     _read_readme(Path(d)) is None
+        ...     read_example_readme(Path(d)) is None
         True
     """
 
@@ -94,19 +101,20 @@ def _extract_description(docstring: str) -> str:
     return text
 
 
-def _df_to_markdown(df: pl.DataFrame, max_rows: int = 20) -> str:
+def df_to_markdown(df: pl.DataFrame, max_rows: int = 20) -> str:
     """Render a Polars DataFrame as a Markdown table.
 
-    Truncates to *max_rows* to keep examples readable.
+    Truncates to *max_rows* to keep examples readable. Exposed publicly so subclass overrides of
+    :meth:`StageExample.render_content` can reuse the same table formatting.
 
     Examples:
         >>> import polars as pl
-        >>> print(_df_to_markdown(pl.DataFrame({"a": [1, None], "b": ["x", "y"]})))
+        >>> print(df_to_markdown(pl.DataFrame({"a": [1, None], "b": ["x", "y"]})))
         | **a** | **b** |
         | --- | --- |
         | 1 | x |
         | *null* | y |
-        >>> print(_df_to_markdown(pl.DataFrame({"v": [1, 2, 3]}), max_rows=2))
+        >>> print(df_to_markdown(pl.DataFrame({"v": [1, 2, 3]}), max_rows=2))
         | **v** |
         | --- |
         | 1 |
@@ -142,14 +150,18 @@ def _df_to_markdown(df: pl.DataFrame, max_rows: int = 20) -> str:
     return "\n".join(lines)
 
 
-def _format_dataset(dataset, label: str) -> list[str]:
+def format_dataset(dataset, label: str) -> list[str]:
     """Render a MEDSDataset as labelled Markdown sections with tables.
+
+    Exposed publicly so subclass overrides of :meth:`StageExample.render_content` can reuse this
+    renderer for any object exposing ``_pl_shards`` (a mapping of shard name to
+    :class:`polars.DataFrame`).
 
     Examples:
         >>> from types import SimpleNamespace
         >>> import polars as pl
         >>> ds = SimpleNamespace(_pl_shards={"0": pl.DataFrame({"x": [1]})})
-        >>> lines = _format_dataset(ds, "Test")
+        >>> lines = format_dataset(ds, "Test")
         >>> print("\\n".join(lines))
         **Test:**
         <BLANKLINE>
@@ -168,7 +180,7 @@ def _format_dataset(dataset, label: str) -> list[str]:
         shard_name, df = next(iter(shards.items()))
         lines.append(f"*Shard `{shard_name}`:*")
         lines.append("")
-        lines.append(_df_to_markdown(df))
+        lines.append(df_to_markdown(df))
         lines.append("")
     else:
         for shard_name, df in shards.items():
@@ -176,63 +188,12 @@ def _format_dataset(dataset, label: str) -> list[str]:
                 f'<details markdown="1"><summary>Shard <code>{shard_name}</code> ({df.height} rows)</summary>'
             )
             lines.append("")
-            lines.append(_df_to_markdown(df))
+            lines.append(df_to_markdown(df))
             lines.append("")
             lines.append("</details>")
             lines.append("")
 
     return lines
-
-
-def _format_example(stage_name: str, example, example_dir: Path | None = None) -> str:
-    """Format a single :class:`StageExample` as structured Markdown.
-
-    Renders configuration as YAML, data as Markdown tables, and includes a sample CLI invocation.
-    """
-
-    lines: list[str] = []
-
-    # Per-example description from README.md in the example directory
-    example_readme = _read_readme(example_dir)
-    if example_readme:
-        lines.extend([example_readme, ""])
-
-    # Stage configuration
-    if example.stage_cfg:
-        cfg_str = OmegaConf.to_yaml(OmegaConf.create(example.stage_cfg)).strip()
-        lines.extend(["**Stage configuration:**", "", "```yaml", cfg_str, "```", ""])
-
-    if example.do_use_config_yaml:
-        lines.extend(["> This example uses the stage's `config.yaml` file.", ""])
-
-    # Input data as tables
-    if example.in_data is not None:
-        if isinstance(example.in_data, Path):
-            lines.extend(["**Input files:**", "", "```yaml", example.in_data.read_text().strip(), "```", ""])
-        else:
-            lines.extend(_format_dataset(example.in_data, "Input data"))
-
-    # Expected output data as tables
-    if example.want_data is not None:
-        lines.extend(_format_dataset(example.want_data, "Expected output data"))
-
-    # Expected output metadata as a table
-    if example.want_metadata is not None:
-        lines.extend(["**Expected output metadata:**", ""])
-        lines.append(_df_to_markdown(example.want_metadata))
-        lines.append("")
-
-    # CLI usage hint
-    cfg_parts = [
-        f"stage_cfg.{k}={v}" for k, v in (example.stage_cfg or {}).items() if not isinstance(v, dict)
-    ]
-    cmd = f"MEDS_transform-stage <pipeline.yaml> {stage_name}"
-    if cfg_parts:
-        cmd += " " + " ".join(cfg_parts)
-    cmd += " input_dir=<input> output_dir=<output>"
-    lines.extend(["**Run this stage:**", "", "```bash", cmd, "```", ""])
-
-    return "\n".join(lines)
 
 
 def _build_stage_content(stage_name: str, stage) -> str:
@@ -249,7 +210,7 @@ def _build_stage_content(stage_name: str, stage) -> str:
             lines.append(description)
 
     # Stage-level README (from the stage directory itself)
-    stage_readme = _read_readme(stage.stage_dir)
+    stage_readme = read_example_readme(stage.stage_dir)
     if stage_readme:
         lines.extend(["", stage_readme])
 
@@ -294,7 +255,7 @@ def _build_stage_content(stage_name: str, stage) -> str:
         lines.append("## Examples")
 
         # Examples-level README (overview of all examples)
-        examples_readme = _read_readme(stage.examples_dir)
+        examples_readme = read_example_readme(stage.examples_dir)
         if examples_readme:
             lines.extend(["", examples_readme])
 
@@ -302,9 +263,29 @@ def _build_stage_content(stage_name: str, stage) -> str:
             scenario_name = scenario or "default"
             example_dir = stage.examples_dir / scenario if stage.examples_dir and scenario else None
             lines.extend(["", f"### {scenario_name}", ""])
-            lines.append(_format_example(stage_name, example, example_dir))
+            lines.extend(example.render_content(example_dir))
 
     return "\n".join(lines)
+
+
+def _safe_relative_to(path: Path, root: Path) -> Path | None:
+    """Return ``path`` relative to ``root``, or ``None`` if ``path`` is not under ``root``.
+
+    Used for MkDocs edit links when the stage lives outside the package ``root`` being documented
+    (e.g., ``generate_stage_docs(\"downstream_pkg\")`` invoked from a MEDS-Transforms docs build).
+
+    Examples:
+        >>> from pathlib import Path
+        >>> _safe_relative_to(Path("/a/b/c"), Path("/a")).as_posix()
+        'b/c'
+        >>> _safe_relative_to(Path("/other/place"), Path("/a")) is None
+        True
+    """
+
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return None
 
 
 def generate_stage_docs(package: str, root: Path | None = None) -> list[StageDoc]:
@@ -313,7 +294,9 @@ def generate_stage_docs(package: str, root: Path | None = None) -> list[StageDoc
     Args:
         package: Package prefix used to filter stages from the registry.
         root: Repository root for computing edit links. Defaults to two
-            directories above this file.
+            directories above this file. Stages whose ``stage_dir`` lives outside
+            ``root`` get a ``None`` ``edit_path`` (no MkDocs edit link) rather
+            than raising.
 
     Returns:
         A list of :class:`StageDoc` objects describing each page.
@@ -333,6 +316,14 @@ def generate_stage_docs(package: str, root: Path | None = None) -> list[StageDoc
 
         >>> generate_stage_docs("fake_package")
         []
+
+    When a stage's ``stage_dir`` is outside the ``root`` used for edit links, ``edit_path`` falls
+    back to ``None`` instead of raising:
+
+        >>> from pathlib import Path
+        >>> docs_no_edit = generate_stage_docs("MEDS_transforms", root=Path("/nonexistent"))
+        >>> all(d.edit_path is None for d in docs_no_edit)
+        True
     """
 
     root = Path(root) if root else Path(__file__).resolve().parents[1]
@@ -345,11 +336,17 @@ def generate_stage_docs(package: str, root: Path | None = None) -> list[StageDoc
 
         stage = entry_point.load()
         content = _build_stage_content(stage_name, stage)
-        edit_path = stage.stage_dir.relative_to(root) if stage.stage_dir else None
+        edit_path = _safe_relative_to(stage.stage_dir, root) if stage.stage_dir else None
 
         docs.append(StageDoc(stage_name, stage_name, content, edit_path))
 
     return docs
 
 
-__all__ = ["StageDoc", "generate_stage_docs"]
+__all__ = [
+    "StageDoc",
+    "df_to_markdown",
+    "format_dataset",
+    "generate_stage_docs",
+    "read_example_readme",
+]

--- a/src/MEDS_transforms/stages/docgen.py
+++ b/src/MEDS_transforms/stages/docgen.py
@@ -69,6 +69,15 @@ def read_example_readme(directory: Path | None) -> str | None:
         ...     _ = (Path(d) / "README.md").write_text("### Deep Heading\\n\\nDeep body.\\n")
         ...     read_example_readme(Path(d))
         'Deep body.'
+
+        A heading-only README (no body) returns ``None`` — the heading is stripped even without a
+        trailing newline:
+
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     _ = (Path(d) / "README.md").write_text("# Just A Heading")
+        ...     read_example_readme(Path(d)) is None
+        True
+
         >>> with tempfile.TemporaryDirectory() as d:
         ...     read_example_readme(Path(d)) is None
         True
@@ -81,7 +90,8 @@ def read_example_readme(directory: Path | None) -> str | None:
         return None
     text = readme.read_text().strip()
     # Strip a leading ATX heading (``# Title``, ``## Sub``, etc.) to avoid duplicate/conflicting headings.
-    text = re.sub(r"^#+[^\n]*\n+", "", text).strip()
+    # Anchor to end-of-string too so heading-only READMEs (no body) are handled.
+    text = re.sub(r"^#+[^\n]*(?:\n+|$)", "", text).strip()
     return text or None
 
 
@@ -275,6 +285,10 @@ def _build_stage_content(stage_name: str, stage) -> str:
 def _safe_relative_to(path: Path, root: Path) -> Path | None:
     """Return ``path`` relative to ``root``, or ``None`` if ``path`` is not under ``root``.
 
+    Both operands are resolved first, so an absolute ``path`` against a relative ``root`` (or vice
+    versa) is handled consistently — otherwise ``Path.relative_to`` would spuriously report
+    "not under root" whenever the two disagreed on absoluteness.
+
     Used for MkDocs edit links when the stage lives outside the package ``root`` being documented
     (e.g., ``generate_stage_docs(\"downstream_pkg\")`` invoked from a MEDS-Transforms docs build).
 
@@ -284,10 +298,25 @@ def _safe_relative_to(path: Path, root: Path) -> Path | None:
         'b/c'
         >>> _safe_relative_to(Path("/other/place"), Path("/a")) is None
         True
+
+        Mixed absolute/relative operands are normalized (both resolved) before comparison:
+
+        >>> import os, tempfile
+        >>> with tempfile.TemporaryDirectory() as td:
+        ...     nested = Path(td) / "pkg" / "stage"
+        ...     nested.mkdir(parents=True)
+        ...     prev = os.getcwd()
+        ...     os.chdir(td)
+        ...     try:
+        ...         rel = _safe_relative_to(nested, Path("pkg"))
+        ...     finally:
+        ...         os.chdir(prev)
+        >>> rel.as_posix()
+        'stage'
     """
 
     try:
-        return path.relative_to(root)
+        return path.resolve().relative_to(Path(root).resolve())
     except ValueError:
         return None
 
@@ -297,10 +326,12 @@ def generate_stage_docs(package: str, root: Path | None = None) -> list[StageDoc
 
     Args:
         package: Package prefix used to filter stages from the registry.
-        root: Repository root for computing edit links. Defaults to two
-            directories above this file. Stages whose ``stage_dir`` lives outside
-            ``root`` get a ``None`` ``edit_path`` (no MkDocs edit link) rather
-            than raising.
+        root: Base directory used to compute *package-relative* ``edit_path`` values (e.g.,
+            ``stages/<stage_name>`` when documenting the ``MEDS_transforms`` package). Defaults
+            to the ``MEDS_transforms`` package directory — i.e., ``docgen.py``'s parent-of-parent
+            — not the repository root. Downstream-package docs builds should pass their own
+            package root. Stages whose ``stage_dir`` lives outside ``root`` get a ``None``
+            ``edit_path`` (no MkDocs edit link) rather than raising.
 
     Returns:
         A list of :class:`StageDoc` objects describing each page.

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -1193,7 +1193,34 @@ class StageExample:
             **Custom section**
             <BLANKLINE>
             wants: 1 codes
-        """
+
+            The CLI hint is built from ``self.cmd_args``, so non-string ``stage_cfg`` values
+            (``bool``, ``None``, ``list``) render as valid Hydra dotlist syntax rather than raw
+            Python ``repr``:
+
+            >>> with_overrides = StageExample(
+            ...     stage_name="demo",
+            ...     want_metadata=metadata_df,
+            ...     stage_cfg={"drop": True, "missing": None},
+            ... )
+            >>> cli = next(
+            ...     line for line in with_overrides.render_content() if "MEDS_transform-stage" in line
+            ... )
+            >>> print(cli)
+            MEDS_transform-stage <pipeline.yaml> demo stage_cfg.drop=true ~stage_cfg.missing input_dir=<input> output_dir=<output>
+
+            When ``do_use_config_yaml`` is set, the hint carries no dotlist overrides (they live in
+            ``config.yaml``):
+
+            >>> via_yaml = StageExample(
+            ...     stage_name="demo",
+            ...     want_metadata=metadata_df,
+            ...     stage_cfg={"drop": True},
+            ...     do_use_config_yaml=True,
+            ... )
+            >>> next(line for line in via_yaml.render_content() if "MEDS_transform-stage" in line)
+            'MEDS_transform-stage <pipeline.yaml> demo input_dir=<input> output_dir=<output>'
+        """  # noqa: E501
 
         from .docgen import df_to_markdown, format_dataset, read_example_readme
 
@@ -1236,12 +1263,12 @@ class StageExample:
             lines.append(df_to_markdown(self.want_metadata))
             lines.append("")
 
-        cfg_parts = [
-            f"stage_cfg.{k}={v}" for k, v in (self.stage_cfg or {}).items() if not isinstance(v, dict)
-        ]
+        # Use the same dotlist formatter as ``self.test_env`` so the rendered command line
+        # matches how the example actually runs (handles bool/None/list values correctly and
+        # yields no overrides when ``do_use_config_yaml`` is set — config.yaml supplies them).
         cmd = f"MEDS_transform-stage <pipeline.yaml> {self.stage_name}"
-        if cfg_parts:
-            cmd += " " + " ".join(cfg_parts)
+        if self.cmd_args:
+            cmd += " " + " ".join(self.cmd_args)
         cmd += " input_dir=<input> output_dir=<output>"
         lines.extend(["**Run this stage:**", "", "```bash", cmd, "```", ""])
 

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -1128,7 +1128,7 @@ class StageExample:
 
         The default implementation renders, in order:
 
-        - optional ``example_dir/README.md`` as a preamble (leading ATX heading stripped),
+        - optional ``example_dir/README.md`` as a preamble (leading ATX heading of any level stripped),
         - ``stage_cfg`` as a YAML code block when non-empty,
         - a note when ``do_use_config_yaml`` is set,
         - ``in_data`` as Markdown shard tables (:class:`MEDSDataset`) or a YAML code block when it is

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -1123,6 +1123,130 @@ class StageExample:
             except AssertionError as e:
                 raise AssertionError("\n".join(err_lines)) from e
 
+    def render_content(self, example_dir: Path | None = None) -> list[str]:
+        """Return Markdown lines rendering this example for ``generate_stage_docs``.
+
+        The default implementation renders, in order:
+
+        - optional ``example_dir/README.md`` as a preamble (leading ATX heading stripped),
+        - ``stage_cfg`` as a YAML code block when non-empty,
+        - a note when ``do_use_config_yaml`` is set,
+        - ``in_data`` as Markdown shard tables (:class:`MEDSDataset`) or a YAML code block when it is
+          a :class:`~pathlib.Path` to a ``yaml_to_disk`` spec,
+        - ``want_data`` with the same MEDSDataset/Path dispatch as ``in_data``,
+        - ``want_metadata`` as a single Markdown table,
+        - a bash invocation hint under a ``**Run this stage:**`` heading.
+
+        Subclasses override this method when their example fields (``in_data``, ``want_data``,
+        ``want_metadata``) aren't :class:`MEDSDataset` / :class:`polars.DataFrame` instances.
+        :func:`MEDS_transforms.stages.docgen.df_to_markdown` and
+        :func:`MEDS_transforms.stages.docgen.format_dataset` are the reusable helpers for such
+        overrides.
+
+        Args:
+            example_dir: Optional directory containing an ``README.md`` to render as a per-example
+                preamble. ``None`` disables the preamble.
+
+        Returns:
+            A list of Markdown lines (suitable for ``\\n``-joining) describing this example.
+
+        Examples:
+            >>> import polars as pl
+            >>> metadata_df = pl.DataFrame({"code": ["foo"], "description": ["Foo"]})
+            >>> example = StageExample(stage_name="demo", want_metadata=metadata_df)
+            >>> print("\\n".join(example.render_content()))
+            **Expected output metadata:**
+            <BLANKLINE>
+            | **code** | **description** |
+            | --- | --- |
+            | foo | Foo |
+            <BLANKLINE>
+            **Run this stage:**
+            <BLANKLINE>
+            ```bash
+            MEDS_transform-stage <pipeline.yaml> demo input_dir=<input> output_dir=<output>
+            ```
+            <BLANKLINE>
+
+            When ``in_data`` is a :class:`~pathlib.Path` to a ``yaml_to_disk`` spec, its raw text is
+            rendered as a YAML code block under an ``**Input files:**`` heading. ``want_data`` uses
+            the same dispatch:
+
+            >>> import tempfile
+            >>> with tempfile.TemporaryDirectory() as d:
+            ...     spec_fp = Path(d) / "out_data.yaml"
+            ...     _ = spec_fp.write_text("foo.json:\\n  a: 1\\n")
+            ...     ex = StageExample(stage_name="demo", want_data=spec_fp)
+            ...     rendered = "\\n".join(ex.render_content())
+            >>> "**Expected output files:**" in rendered
+            True
+            >>> "foo.json:" in rendered
+            True
+
+            Subclasses override this method to render non-MEDS outputs:
+
+            >>> class TextOutputExample(StageExample):
+            ...     def render_content(self, example_dir=None):
+            ...         return ["**Custom section**", "", f"wants: {self.want_metadata.height} codes"]
+            >>> custom = TextOutputExample(stage_name="demo", want_metadata=metadata_df)
+            >>> print("\\n".join(custom.render_content()))
+            **Custom section**
+            <BLANKLINE>
+            wants: 1 codes
+        """
+
+        from .docgen import df_to_markdown, format_dataset, read_example_readme
+
+        lines: list[str] = []
+
+        example_readme = read_example_readme(example_dir)
+        if example_readme:
+            lines.extend([example_readme, ""])
+
+        if self.stage_cfg:
+            cfg_str = OmegaConf.to_yaml(OmegaConf.create(self.stage_cfg)).strip()
+            lines.extend(["**Stage configuration:**", "", "```yaml", cfg_str, "```", ""])
+
+        if self.do_use_config_yaml:
+            lines.extend(["> This example uses the stage's `config.yaml` file.", ""])
+
+        if self.in_data is not None:
+            if isinstance(self.in_data, Path):
+                lines.extend(["**Input files:**", "", "```yaml", self.in_data.read_text().strip(), "```", ""])
+            else:
+                lines.extend(format_dataset(self.in_data, "Input data"))
+
+        if self.want_data is not None:
+            if isinstance(self.want_data, Path):
+                lines.extend(
+                    [
+                        "**Expected output files:**",
+                        "",
+                        "```yaml",
+                        self.want_data.read_text().strip(),
+                        "```",
+                        "",
+                    ]
+                )
+            else:
+                lines.extend(format_dataset(self.want_data, "Expected output data"))
+
+        if self.want_metadata is not None:
+            lines.extend(["**Expected output metadata:**", ""])
+            lines.append(df_to_markdown(self.want_metadata))
+            lines.append("")
+
+        cfg_parts = [
+            f"stage_cfg.{k}={v}" for k, v in (self.stage_cfg or {}).items() if not isinstance(v, dict)
+        ]
+        cmd = f"MEDS_transform-stage <pipeline.yaml> {self.stage_name}"
+        if cfg_parts:
+            cmd += " " + " ".join(cfg_parts)
+        cmd += " input_dir=<input> output_dir=<output>"
+        lines.extend(["**Run this stage:**", "", "```bash", cmd, "```", ""])
+
+        return lines
+
 
 class StageExampleDict(dict):
     """A dictionary subclass to hold stage examples.

--- a/tests/test_generic_input.py
+++ b/tests/test_generic_input.py
@@ -178,8 +178,6 @@ def test_pipeline_cfg_in_str():
 
 def test_docgen_with_generic_input():
     """Docgen should render non-MEDS input as a YAML code block."""
-    from MEDS_transforms.stages.docgen import _format_example
-
     want_data = MEDSDataset.from_yaml(SIMPLE_STATIC_SHARDED_BY_SPLIT)
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -192,9 +190,9 @@ def test_docgen_with_generic_input():
             want_data=want_data,
             in_data=in_fp,
         )
-        output = _format_example("test_stage", example)
+        output = "\n".join(example.render_content())
         assert "**Input files:**" in output
         assert "```yaml" in output
         assert "raw/patients.csv" in output
-        # Should NOT contain _format_dataset output
+        # Should NOT contain format_dataset output for in_data
         assert "**Input data:**" not in output


### PR DESCRIPTION
## Summary

- Moves per-example rendering out of the free-function `_format_example` in `MEDS_transforms/stages/docgen.py` onto `StageExample.render_content(example_dir=None)`, so downstream packages whose stages register with a custom `example_class` can override rendering without monkey-patching docgen.
- Adds a symmetric `Path` branch for `want_data` (mirrors the existing `in_data` handling), resolving the immediate `AttributeError: 'PosixPath' object has no attribute '_pl_shards'` that any subclass using a YAML-spec path as `want_data` hit.
- Promotes `df_to_markdown` and `format_dataset` to public utilities on `docgen` so subclass overrides can reuse them.
- Makes `generate_stage_docs` tolerate stages whose `stage_dir` lives outside the `root` passed for edit-link computation (returns `None` for `edit_path` instead of raising).
- Demonstrates the hook: `simple_example_pkg.export_code_summary.JsonOutputStageExample` overrides `render_content` to parse its JSON output spec and render each file as a Markdown table.

## Design

See https://github.com/mmcdermott/MEDS_transforms/issues/383#issuecomment-4273777225 for the full design proposal.

## Test plan

- [x] `uv run pytest src/MEDS_transforms/stages/docgen.py src/MEDS_transforms/stages/examples.py --doctest-modules` — doctests on the new method and utilities pass.
- [x] `uv run pytest tests/test_generic_input.py` — updated to use `render_content`.
- [x] `uv run pytest example/simple_example_pkg/tests/test_registered_stages.py` — new end-to-end assertion that `generate_stage_docs("simple_example_pkg", root=…)` renders the subclass-customized JSON table.
- [x] `uv run ruff check` / `uv run ruff format --check` clean.
- [ ] CI green across all suites.
- [ ] Copilot review iterated to no outstanding comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)