### PR TITLE
In-memory execution mode for MEDS-Transforms pipelines

### DIFF
--- a/src/MEDS_transforms/compute_modes/__init__.py
+++ b/src/MEDS_transforms/compute_modes/__init__.py
@@ -1,5 +1,12 @@
 from .compute_fn import ANY_COMPUTE_FN_T, COMPUTE_FN_T, bind_compute_fn
-from .in_memory import FrameRegistry, active_registry, in_memory_mode
+from .in_memory import (
+    FrameRegistry,
+    active_registry,
+    in_memory_mode,
+    in_memory_read,
+    in_memory_write,
+    try_in_memory_read,
+)
 from .match_revise import is_match_revise, match_revise_fntr
 
 __all__ = [
@@ -7,6 +14,9 @@ __all__ = [
     "active_registry",
     "bind_compute_fn",
     "in_memory_mode",
+    "in_memory_read",
+    "in_memory_write",
     "is_match_revise",
     "match_revise_fntr",
+    "try_in_memory_read",
 ]

--- a/src/MEDS_transforms/compute_modes/__init__.py
+++ b/src/MEDS_transforms/compute_modes/__init__.py
@@ -1,4 +1,12 @@
 from .compute_fn import ANY_COMPUTE_FN_T, COMPUTE_FN_T, bind_compute_fn
+from .in_memory import FrameRegistry, active_registry, in_memory_mode
 from .match_revise import is_match_revise, match_revise_fntr
 
-__all__ = ["bind_compute_fn", "is_match_revise", "match_revise_fntr"]
+__all__ = [
+    "FrameRegistry",
+    "active_registry",
+    "bind_compute_fn",
+    "in_memory_mode",
+    "is_match_revise",
+    "match_revise_fntr",
+]

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -66,14 +66,28 @@ class FrameRegistry:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._frames: dict[Path, DF_T] = {}
+        # Paths currently being written by a worker; used by ``try_reserve_write`` to preserve
+        # the mutual-exclusion semantics that ``FileLock`` provides in disk mode.
+        self._in_progress: set[Path] = set()
 
     def put(self, fp: str | Path, df: DF_T) -> None:
         with self._lock:
             self._frames[Path(fp)] = df
 
     def get(self, fp: str | Path) -> DF_T:
+        """Fetch the frame keyed by ``fp``. Raises ``KeyError`` with a registry-scoped message.
+
+        The bare-dict ``KeyError`` would just show the Path repr; this version makes it obvious
+        that the failure is "registry wasn't seeded" rather than "file missing on disk".
+        """
+        key = Path(fp)
         with self._lock:
-            return self._frames[Path(fp)]
+            if key not in self._frames:
+                raise KeyError(
+                    f"In-memory FrameRegistry has no frame registered for path: {key!s}. "
+                    f"Known keys: {sorted(str(k) for k in self._frames)}"
+                )
+            return self._frames[key]
 
     def has(self, fp: str | Path) -> bool:
         with self._lock:
@@ -83,8 +97,39 @@ class FrameRegistry:
         with self._lock:
             return list(self._frames.keys())
 
+    def try_reserve_write(self, fp: str | Path) -> bool:
+        """Reserve ``fp`` for writing if no other worker is currently holding it.
+
+        Returns ``True`` if the caller obtained the reservation (and must pair it with
+        ``release_write``). Returns ``False`` if the path is already in progress — mirroring
+        disk mode where ``FileLock.acquire(timeout=0)`` raises ``Timeout`` and
+        ``rwlock_wrap`` returns ``False`` without running ``compute_fn``.
+
+        Examples:
+            >>> reg = FrameRegistry()
+            >>> reg.try_reserve_write("/virtual/out.parquet")
+            True
+            >>> reg.try_reserve_write("/virtual/out.parquet")
+            False
+            >>> reg.release_write("/virtual/out.parquet")
+            >>> reg.try_reserve_write("/virtual/out.parquet")
+            True
+        """
+        key = Path(fp)
+        with self._lock:
+            if key in self._in_progress:
+                return False
+            self._in_progress.add(key)
+            return True
+
+    def release_write(self, fp: str | Path) -> None:
+        """Release a reservation previously obtained via ``try_reserve_write``."""
+        with self._lock:
+            self._in_progress.discard(Path(fp))
+
 
 _registry: FrameRegistry | None = None
+_registry_lock = threading.Lock()
 
 
 def active_registry() -> FrameRegistry | None:
@@ -191,10 +236,13 @@ def in_memory_mode(registry: FrameRegistry | None = None) -> Iterator[FrameRegis
         RuntimeError: in_memory_mode is not re-entrant
     """
     global _registry
-    if _registry is not None:
-        raise RuntimeError("in_memory_mode is not re-entrant")
-    _registry = registry if registry is not None else FrameRegistry()
+    with _registry_lock:
+        if _registry is not None:
+            raise RuntimeError("in_memory_mode is not re-entrant")
+        _registry = registry if registry is not None else FrameRegistry()
+        installed = _registry
     try:
-        yield _registry
+        yield installed
     finally:
-        _registry = None
+        with _registry_lock:
+            _registry = None

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -74,6 +74,27 @@ class FrameRegistry:
         with self._lock:
             self._frames[Path(fp)] = df
 
+    def delete(self, fp: str | Path) -> bool:
+        """Remove the frame keyed by ``fp``. Returns ``True`` if a frame was removed.
+
+        Used by the in-memory fast path to mirror disk mode's ``out_fp.unlink()`` when
+        ``do_overwrite=True``: evicting before recompute ensures a crash in ``compute_fn`` can't
+        leave a stale entry that a later ``do_overwrite=False`` call would incorrectly treat as
+        a cache hit.
+
+        Examples:
+            >>> reg = FrameRegistry()
+            >>> reg.put("/virtual/shard.parquet", pl.LazyFrame({"a": [1]}))
+            >>> reg.delete("/virtual/shard.parquet")
+            True
+            >>> reg.has("/virtual/shard.parquet")
+            False
+            >>> reg.delete("/virtual/shard.parquet")
+            False
+        """
+        with self._lock:
+            return self._frames.pop(Path(fp), None) is not None
+
     def get(self, fp: str | Path) -> DF_T:
         """Fetch the frame keyed by ``fp``. Raises ``KeyError`` with a registry-scoped message.
 

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -191,6 +191,42 @@ def in_memory_read(fp: str | Path) -> DF_T:
     return reg.get(fp)
 
 
+def try_in_memory_read(fp: str | Path) -> DF_T | None:
+    """Return the registry-stored frame for ``fp`` if one exists; otherwise ``None``.
+
+    Used by ``read_df`` to layer the registry on top of the on-disk store: a registry hit
+    short-circuits the parquet scan, but a miss falls through to disk so the first stage of a
+    pipeline can read the original on-disk inputs without manual pre-seeding. This keeps "skip
+    intermediate IO" as the only behavior the registry adds — it never blocks reads of files
+    the registry hasn't been told about.
+
+    Returns ``None`` if no registry is active.
+
+    Examples:
+        >>> try_in_memory_read("/anywhere") is None
+        True
+        >>> with in_memory_mode() as reg:
+        ...     print(try_in_memory_read("/virtual/missing.parquet"))
+        ...     reg.put("/virtual/shard.parquet", pl.LazyFrame({"a": [1]}))
+        ...     print(try_in_memory_read("/virtual/shard.parquet").collect())
+        None
+        shape: (1, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        └─────┘
+    """
+    reg = active_registry()
+    if reg is None:
+        return None
+    if not reg.has(fp):
+        return None
+    return reg.get(fp)
+
+
 def in_memory_write(df: DF_T, fp: str | Path) -> None:
     """Store a frame into the active registry. Raises if no registry is active.
 

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -103,9 +103,21 @@ def active_registry() -> FrameRegistry | None:
 
 
 def in_memory_read(fp: str | Path) -> DF_T:
-    """Fetch a frame from the active registry.
+    """Fetch a frame from the active registry. Raises if no registry is active.
 
-    Raises if no registry is active.
+    Examples:
+        >>> with in_memory_mode() as reg:
+        ...     reg.put("/virtual/shard.parquet", pl.LazyFrame({"a": [1, 2]}))
+        ...     print(in_memory_read("/virtual/shard.parquet").collect())
+        shape: (2, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        │ 2   │
+        └─────┘
     """
     reg = active_registry()
     if reg is None:  # pragma: no cover - defensive

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -1,0 +1,176 @@
+"""In-memory execution mode: skip parquet round-trips between MAP stages.
+
+This module provides a process-local ``FrameRegistry`` keyed by the logical filesystem path a
+stage would otherwise read/write, plus a context manager that activates it for the duration of an
+in-process pipeline run. While a registry is active:
+
+- The default ``read_df`` / ``write_df`` (in :mod:`MEDS_transforms.dataframe`) transparently
+  round-trip through the registry instead of touching parquet.
+- ``rwlock_wrap`` (in :mod:`MEDS_transforms.mapreduce.rwlock`) skips its filesystem ``FileLock``
+  and ``out_fp_checker``, because in a single-process in-memory run there is no cross-worker
+  contention to arbitrate.
+
+Stages that register their own ``read_fn`` / ``write_fn`` at ``Stage.register`` time bypass the
+default and therefore also bypass this mechanism — they keep doing whatever they did before.
+
+Scope (Phase 0): MAP stages only. MAPREDUCE stages still perform their file-based reduce
+handshake; wiring the reducer through the registry is a follow-up. A ``MAIN`` stage that reads
+and writes parquet directly also stays on disk.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..dataframe.types import DF_T
+
+
+class FrameRegistry:
+    """Thread-safe map from (logical) output path to in-memory ``DataFrame`` / ``LazyFrame``.
+
+    Paths are used only as opaque keys — they are never opened or written to. The registry
+    normalizes incoming paths with ``Path()`` so callers may pass ``str`` or ``Path``
+    interchangeably.
+
+    Examples:
+        >>> reg = FrameRegistry()
+        >>> reg.has(Path("/tmp/nope.parquet"))
+        False
+        >>> df = pl.DataFrame({"a": [1, 2, 3]})
+        >>> reg.put(Path("/tmp/shard.parquet"), df)
+        >>> reg.has("/tmp/shard.parquet")
+        True
+        >>> reg.get("/tmp/shard.parquet")
+        shape: (3, 1)
+        ┌─────┐
+        │ a   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 1   │
+        │ 2   │
+        │ 3   │
+        └─────┘
+        >>> sorted(str(p) for p in reg.keys())
+        ['/tmp/shard.parquet']
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._frames: dict[Path, DF_T] = {}
+
+    def put(self, fp: str | Path, df: DF_T) -> None:
+        with self._lock:
+            self._frames[Path(fp)] = df
+
+    def get(self, fp: str | Path) -> DF_T:
+        with self._lock:
+            return self._frames[Path(fp)]
+
+    def has(self, fp: str | Path) -> bool:
+        with self._lock:
+            return Path(fp) in self._frames
+
+    def keys(self) -> list[Path]:
+        with self._lock:
+            return list(self._frames.keys())
+
+
+_registry: FrameRegistry | None = None
+
+
+def active_registry() -> FrameRegistry | None:
+    """Return the currently installed ``FrameRegistry``, or ``None`` if disk mode is active.
+
+    Examples:
+        >>> active_registry() is None
+        True
+        >>> with in_memory_mode() as reg:
+        ...     active_registry() is reg
+        True
+        >>> active_registry() is None
+        True
+    """
+    return _registry
+
+
+def in_memory_read(fp: str | Path) -> DF_T:
+    """Fetch a frame from the active registry.
+
+    Raises if no registry is active.
+    """
+    reg = active_registry()
+    if reg is None:  # pragma: no cover - defensive
+        raise RuntimeError("in_memory_read called outside of an in_memory_mode context")
+    return reg.get(fp)
+
+
+def in_memory_write(df: DF_T, fp: str | Path) -> None:
+    """Store a frame into the active registry. Raises if no registry is active.
+
+    Collects lazy frames eagerly so each stage's output is materialized at the point of write, preventing
+    later stages from accidentally re-triggering an earlier stage's compute graph.
+    """
+    reg = active_registry()
+    if reg is None:  # pragma: no cover - defensive
+        raise RuntimeError("in_memory_write called outside of an in_memory_mode context")
+    if isinstance(df, pl.LazyFrame):
+        df = df.collect().lazy()
+    reg.put(fp, df)
+
+
+@contextmanager
+def in_memory_mode(registry: FrameRegistry | None = None) -> Iterator[FrameRegistry]:
+    """Activate in-memory execution for the duration of the ``with`` block.
+
+    Args:
+        registry: An existing registry to install. If ``None``, a fresh one is created. Passing
+            an existing registry lets a caller seed input shards before entering the context or
+            inspect outputs after exiting.
+
+    Yields:
+        The active ``FrameRegistry``.
+
+    Raises:
+        RuntimeError: If a registry is already active in the current process.
+
+    Examples:
+        >>> with in_memory_mode() as reg:
+        ...     reg.put("in/shard_0.parquet", pl.DataFrame({"x": [1, 2]}))
+        ...     print(active_registry() is reg)
+        True
+
+        A registry can be constructed outside the block and handed in:
+
+        >>> seeded = FrameRegistry()
+        >>> seeded.put("in/shard_0.parquet", pl.DataFrame({"x": [1, 2]}))
+        >>> with in_memory_mode(seeded) as reg:
+        ...     print(reg is seeded)
+        True
+
+        Nested activation is rejected — the mechanism is process-global state, and two layers of
+        in-memory mode would be ambiguous:
+
+        >>> with in_memory_mode():
+        ...     with in_memory_mode():
+        ...         pass
+        Traceback (most recent call last):
+            ...
+        RuntimeError: in_memory_mode is not re-entrant
+    """
+    global _registry
+    if _registry is not None:
+        raise RuntimeError("in_memory_mode is not re-entrant")
+    _registry = registry if registry is not None else FrameRegistry()
+    try:
+        yield _registry
+    finally:
+        _registry = None

--- a/src/MEDS_transforms/compute_modes/in_memory.py
+++ b/src/MEDS_transforms/compute_modes/in_memory.py
@@ -128,15 +128,27 @@ def in_memory_read(fp: str | Path) -> DF_T:
 def in_memory_write(df: DF_T, fp: str | Path) -> None:
     """Store a frame into the active registry. Raises if no registry is active.
 
-    Collects lazy frames eagerly so each stage's output is materialized at the point of write, preventing
-    later stages from accidentally re-triggering an earlier stage's compute graph.
+    Materializes the frame and stores it as a fresh ``LazyFrame`` so reads via ``read_df`` return
+    the same type they would in disk mode (where ``pl.scan_parquet`` yields ``LazyFrame``). This
+    prevents type drift across chained MAP stages regardless of whether the stage's compute
+    function returns an eager ``pl.DataFrame`` or a ``pl.LazyFrame``. Collecting at write time
+    also severs any lingering compute-graph references to the previous stage.
+
+    Examples:
+        >>> with in_memory_mode() as reg:
+        ...     in_memory_write(pl.DataFrame({"a": [1, 2]}), "/eager/shard.parquet")
+        ...     in_memory_write(pl.LazyFrame({"a": [3, 4]}), "/lazy/shard.parquet")
+        ...     print(type(reg.get("/eager/shard.parquet")).__name__)
+        ...     print(type(reg.get("/lazy/shard.parquet")).__name__)
+        LazyFrame
+        LazyFrame
     """
     reg = active_registry()
     if reg is None:  # pragma: no cover - defensive
         raise RuntimeError("in_memory_write called outside of an in_memory_mode context")
     if isinstance(df, pl.LazyFrame):
-        df = df.collect().lazy()
-    reg.put(fp, df)
+        df = df.collect()
+    reg.put(fp, df.lazy())
 
 
 @contextmanager

--- a/src/MEDS_transforms/dataframe/read_fn.py
+++ b/src/MEDS_transforms/dataframe/read_fn.py
@@ -22,11 +22,10 @@ def read_df(in_fp: Path) -> DF_T:
     context, reads go to disk via ``pl.scan_parquet``.
     """
 
-    from ..compute_modes.in_memory import active_registry
+    from ..compute_modes.in_memory import active_registry, in_memory_read
 
-    reg = active_registry()
-    if reg is not None:
-        return reg.get(in_fp)
+    if active_registry() is not None:
+        return in_memory_read(in_fp)
     return pl.scan_parquet(in_fp, glob=False)
 
 

--- a/src/MEDS_transforms/dataframe/read_fn.py
+++ b/src/MEDS_transforms/dataframe/read_fn.py
@@ -14,8 +14,19 @@ READ_FN_T = Callable[[Path], DF_T]
 
 
 def read_df(in_fp: Path) -> DF_T:
-    """A generic helper to read a dataframe without accounting for globs."""
+    """A generic helper to read a dataframe without accounting for globs.
 
+    When an in-memory ``FrameRegistry`` is active (see
+    :func:`MEDS_transforms.compute_modes.in_memory_mode`), the frame keyed by ``in_fp`` is
+    returned directly from the registry — no parquet scan is performed. Outside an in-memory
+    context, reads go to disk via ``pl.scan_parquet``.
+    """
+
+    from ..compute_modes.in_memory import active_registry
+
+    reg = active_registry()
+    if reg is not None:
+        return reg.get(in_fp)
     return pl.scan_parquet(in_fp, glob=False)
 
 

--- a/src/MEDS_transforms/dataframe/read_fn.py
+++ b/src/MEDS_transforms/dataframe/read_fn.py
@@ -18,14 +18,17 @@ def read_df(in_fp: Path) -> DF_T:
 
     When an in-memory ``FrameRegistry`` is active (see
     :func:`MEDS_transforms.compute_modes.in_memory_mode`), the frame keyed by ``in_fp`` is
-    returned directly from the registry — no parquet scan is performed. Outside an in-memory
-    context, reads go to disk via ``pl.scan_parquet``.
+    returned directly from the registry. On a registry miss the read falls through to disk via
+    ``pl.scan_parquet`` — this lets the first stage of an in-memory pipeline read the original
+    on-disk inputs without manual pre-seeding, while subsequent stages naturally short-circuit
+    through prior stages' registry writes.
     """
 
-    from ..compute_modes.in_memory import active_registry, in_memory_read
+    from ..compute_modes.in_memory import try_in_memory_read
 
-    if active_registry() is not None:
-        return in_memory_read(in_fp)
+    df = try_in_memory_read(in_fp)
+    if df is not None:
+        return df
     return pl.scan_parquet(in_fp, glob=False)
 
 

--- a/src/MEDS_transforms/dataframe/write_fn.py
+++ b/src/MEDS_transforms/dataframe/write_fn.py
@@ -16,7 +16,17 @@ def write_df(df: DF_T, out_fp: Path) -> None:
     ``os.replace`` so concurrent readers never observe a partial parquet file at
     the final path. The rename is atomic on POSIX and Windows as long as
     ``out_fp`` and its staging path share a filesystem.
+
+    When an in-memory ``FrameRegistry`` is active (see
+    :func:`MEDS_transforms.compute_modes.in_memory_mode`), the frame is stored in the registry
+    keyed by ``out_fp`` instead — no parquet is written and no directory is created.
     """
+    from ..compute_modes.in_memory import active_registry, in_memory_write
+
+    if active_registry() is not None:
+        in_memory_write(df, out_fp)
+        return
+
     if isinstance(df, pl.LazyFrame):
         df = df.collect()
     out_fp.parent.mkdir(parents=True, exist_ok=True)

--- a/src/MEDS_transforms/mapreduce/reducer.py
+++ b/src/MEDS_transforms/mapreduce/reducer.py
@@ -8,7 +8,7 @@ from typing import Protocol
 import polars as pl
 
 from ..dataframe import DF_T, READ_FN_T, WRITE_FN_T
-from .rwlock import default_file_checker
+from .rwlock import _uses_default_registry_io, default_file_checker
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +208,21 @@ def reduce_over(
         └─────┴─────┘
     """
 
+    from ..compute_modes.in_memory import active_registry
+
+    reg = active_registry()
+    if reg is not None and _uses_default_registry_io(read_fn, write_fn):
+        return _reduce_over_in_memory(
+            in_fps=in_fps,
+            out_fp=out_fp,
+            read_fn=read_fn,
+            write_fn=write_fn,
+            reduce_fn=reduce_fn,
+            merge_fp=merge_fp,
+            merge_fn=merge_fn,
+            do_overwrite=do_overwrite,
+        )
+
     if out_fp.is_file() and not do_overwrite:
         raise FileExistsError(f"Output file already exists: {out_fp.resolve()!s}")
 
@@ -261,4 +276,49 @@ def reduce_over(
     reduced = reduced.with_columns(s.shrink_dtype() for s in reduced if s.dtype.is_numeric())
 
     out_fp.parent.mkdir(parents=True, exist_ok=True)
+    write_fn(reduced, out_fp)
+
+
+def _reduce_over_in_memory(
+    in_fps: list[Path],
+    out_fp: Path,
+    read_fn: READ_FN_T,
+    write_fn: WRITE_FN_T,
+    reduce_fn: "REDUCE_FN_T",
+    merge_fp: Path | None,
+    merge_fn: "REDUCE_FN_T | None",
+    do_overwrite: bool,
+) -> None:
+    """``reduce_over`` fast path when an in-memory ``FrameRegistry`` is active.
+
+    In single-process in-memory mode, all mapper outputs were written to the registry earlier
+    in the same call sequence, so the cross-worker FS polling that disk mode performs is both
+    unnecessary and incorrect (a missing key never appears later). We delegate the read to
+    ``read_fn`` (which falls back to disk via ``read_df`` for any input not in the registry —
+    e.g., the original dataset files on the first stage) and let ``write_fn`` route the result
+    back into the registry.
+    """
+    from ..compute_modes.in_memory import active_registry
+
+    reg = active_registry()
+    if reg is None:  # pragma: no cover - defensive; caller guards on active_registry
+        raise RuntimeError("_reduce_over_in_memory called outside of an in_memory_mode context")
+
+    if reg.has(out_fp):
+        if do_overwrite:
+            logger.info(f"(in-memory reduce) evicting cached output at {out_fp} (do_overwrite=True)")
+            reg.delete(out_fp)
+        else:
+            logger.info(f"(in-memory reduce) cached output exists at {out_fp}; returning without recompute.")
+            return
+
+    reduced = reduce_fn(*[read_fn(fp) for fp in in_fps])
+
+    if merge_fp is not None and (reg.has(merge_fp) or merge_fp.is_file()):
+        reduced = merge_fn(reduced, read_fn(merge_fp))
+
+    if isinstance(reduced, pl.LazyFrame):
+        reduced = reduced.collect()
+    reduced = reduced.with_columns(s.shrink_dtype() for s in reduced if s.dtype.is_numeric())
+
     write_fn(reduced, out_fp)

--- a/src/MEDS_transforms/mapreduce/rwlock.py
+++ b/src/MEDS_transforms/mapreduce/rwlock.py
@@ -56,6 +56,27 @@ def default_file_checker(fp: Path) -> bool:
     return fp.is_file()
 
 
+def _rwlock_in_memory(
+    in_fp: Path,
+    out_fp: Path,
+    read_fn: READ_FN_T,
+    write_fn: WRITE_FN_T,
+    compute_fn: COMPUTE_FN_T,
+) -> bool:
+    """rwlock_wrap fast path when an in-memory ``FrameRegistry`` is active.
+
+    In-memory runs are single-process and the registry is thread-safe, so the ``FileLock`` and
+    ``out_fp_checker`` are unnecessary — they'd just cause spurious disk IO. We read, compute,
+    and write directly.
+    """
+    logger.info(f"(in-memory) reading input frame keyed by {in_fp}")
+    df = read_fn(in_fp)
+    df = compute_fn(df)
+    logger.info(f"(in-memory) writing output frame keyed by {out_fp}")
+    write_fn(df, out_fp)
+    return True
+
+
 def rwlock_wrap(
     in_fp: Path,
     out_fp: Path,
@@ -140,6 +161,11 @@ def rwlock_wrap(
         >>> assert result_computed
         >>> assert not lock_fp.exists()
     """
+
+    from ..compute_modes.in_memory import active_registry
+
+    if active_registry() is not None:
+        return _rwlock_in_memory(in_fp, out_fp, read_fn, write_fn, compute_fn)
 
     if out_fp_checker(out_fp):
         if do_overwrite:

--- a/src/MEDS_transforms/mapreduce/rwlock.py
+++ b/src/MEDS_transforms/mapreduce/rwlock.py
@@ -56,19 +56,43 @@ def default_file_checker(fp: Path) -> bool:
     return fp.is_file()
 
 
+def _uses_default_registry_io(read_fn: READ_FN_T, write_fn: WRITE_FN_T) -> bool:
+    """Return ``True`` when ``read_fn``/``write_fn`` are the package defaults.
+
+    Only the defaults know how to talk to the ``FrameRegistry``. Stages that pass custom
+    ``read_fn``/``write_fn`` (e.g. CSV, JSON, or any non-parquet IO) continue through the full
+    ``rwlock_wrap`` path so their locking and caching semantics are preserved verbatim.
+    """
+    from ..dataframe import read_df, write_df
+
+    return read_fn is read_df and write_fn is write_df
+
+
 def _rwlock_in_memory(
     in_fp: Path,
     out_fp: Path,
     read_fn: READ_FN_T,
     write_fn: WRITE_FN_T,
     compute_fn: COMPUTE_FN_T,
+    do_overwrite: bool,
 ) -> bool:
     """rwlock_wrap fast path when an in-memory ``FrameRegistry`` is active.
 
-    In-memory runs are single-process and the registry is thread-safe, so the ``FileLock`` and
-    ``out_fp_checker`` are unnecessary — they'd just cause spurious disk IO. We read, compute,
-    and write directly.
+    In-memory runs are single-process and the registry is thread-safe, so the ``FileLock`` is
+    unnecessary — it'd just cause spurious disk IO. Cache semantics are preserved: if the
+    registry already holds ``out_fp`` and ``do_overwrite`` is false, return ``False`` and skip
+    the compute (mirrors disk-mode ``out_fp_checker`` + skip-if-exists).
     """
+    from ..compute_modes.in_memory import active_registry
+
+    reg = active_registry()
+    if reg is not None and reg.has(out_fp):
+        if do_overwrite:
+            logger.info(f"(in-memory) overwriting cached output at {out_fp}")
+        else:
+            logger.info(f"(in-memory) cached output exists at {out_fp}; returning.")
+            return False
+
     logger.info(f"(in-memory) reading input frame keyed by {in_fp}")
     df = read_fn(in_fp)
     df = compute_fn(df)
@@ -164,8 +188,8 @@ def rwlock_wrap(
 
     from ..compute_modes.in_memory import active_registry
 
-    if active_registry() is not None:
-        return _rwlock_in_memory(in_fp, out_fp, read_fn, write_fn, compute_fn)
+    if active_registry() is not None and _uses_default_registry_io(read_fn, write_fn):
+        return _rwlock_in_memory(in_fp, out_fp, read_fn, write_fn, compute_fn, do_overwrite)
 
     if out_fp_checker(out_fp):
         if do_overwrite:

--- a/src/MEDS_transforms/mapreduce/rwlock.py
+++ b/src/MEDS_transforms/mapreduce/rwlock.py
@@ -78,27 +78,42 @@ def _rwlock_in_memory(
 ) -> bool:
     """rwlock_wrap fast path when an in-memory ``FrameRegistry`` is active.
 
-    In-memory runs are single-process and the registry is thread-safe, so the ``FileLock`` is
-    unnecessary — it'd just cause spurious disk IO. Cache semantics are preserved: if the
-    registry already holds ``out_fp`` and ``do_overwrite`` is false, return ``False`` and skip
-    the compute (mirrors disk-mode ``out_fp_checker`` + skip-if-exists).
+    Disk-mode ``rwlock_wrap`` uses two filesystem primitives to coordinate workers: the output
+    file's existence (skip-if-exists, honored by ``out_fp_checker``) and an adjacent
+    ``.lock`` file acquired via ``FileLock`` (mutual exclusion between workers). We replace
+    both with the registry:
+
+    - Skip-if-exists: ``registry.has(out_fp)`` + ``do_overwrite``.
+    - Mutual exclusion: ``registry.try_reserve_write(out_fp)`` — returns ``False`` if another
+      worker is mid-compute on the same key, matching the ``FileLock.Timeout → return False``
+      path in disk mode.
     """
     from ..compute_modes.in_memory import active_registry
 
     reg = active_registry()
-    if reg is not None and reg.has(out_fp):
+    if reg is None:  # pragma: no cover - defensive; caller guards on active_registry
+        raise RuntimeError("_rwlock_in_memory called outside of an in_memory_mode context")
+
+    if reg.has(out_fp):
         if do_overwrite:
             logger.info(f"(in-memory) overwriting cached output at {out_fp}")
         else:
             logger.info(f"(in-memory) cached output exists at {out_fp}; returning.")
             return False
 
-    logger.info(f"(in-memory) reading input frame keyed by {in_fp}")
-    df = read_fn(in_fp)
-    df = compute_fn(df)
-    logger.info(f"(in-memory) writing output frame keyed by {out_fp}")
-    write_fn(df, out_fp)
-    return True
+    if not reg.try_reserve_write(out_fp):
+        logger.info(f"(in-memory) {out_fp} is already in progress on another worker; returning.")
+        return False
+
+    try:
+        logger.info(f"(in-memory) reading input frame keyed by {in_fp}")
+        df = read_fn(in_fp)
+        df = compute_fn(df)
+        logger.info(f"(in-memory) writing output frame keyed by {out_fp}")
+        write_fn(df, out_fp)
+        return True
+    finally:
+        reg.release_write(out_fp)
 
 
 def rwlock_wrap(

--- a/src/MEDS_transforms/mapreduce/rwlock.py
+++ b/src/MEDS_transforms/mapreduce/rwlock.py
@@ -96,7 +96,10 @@ def _rwlock_in_memory(
 
     if reg.has(out_fp):
         if do_overwrite:
-            logger.info(f"(in-memory) overwriting cached output at {out_fp}")
+            logger.info(f"(in-memory) evicting cached output at {out_fp} (do_overwrite=True)")
+            # Evict before reserving/computing so a crash in compute_fn can't leave a stale
+            # entry behind; mirrors disk-mode `out_fp.unlink()` in the same branch.
+            reg.delete(out_fp)
         else:
             logger.info(f"(in-memory) cached output exists at {out_fp}; returning.")
             return False

--- a/src/MEDS_transforms/mapreduce/shard_iteration.py
+++ b/src/MEDS_transforms/mapreduce/shard_iteration.py
@@ -267,6 +267,8 @@ def shard_iterator(
         FileNotFoundError: No shards found in ... with suffix .parquet. Directory contents:...
     """
 
+    from ..compute_modes import active_registry
+
     input_dir = Path(cfg.stage_cfg.data_input_dir)
     output_dir = Path(cfg.stage_cfg.output_dir)
 
@@ -275,12 +277,31 @@ def shard_iterator(
     if in_prefix:
         input_dir = input_dir / in_prefix
 
-    shards = []
+    shards: list[str] = []
     for p in input_dir.glob(f"**/*{in_suffix}"):
         relative_path = p.relative_to(input_dir)
-        shard_name = str(relative_path)
-        shard_name = shard_name[: -len(in_suffix)]
+        shard_name = str(relative_path)[: -len(in_suffix)]
         shards.append(shard_name)
+
+    # Layer registry-keyed shards on top of any disk shards. In-memory mode keys frames by the
+    # logical output path that the previous stage *would have* written, so when a downstream
+    # stage's ``data_input_dir`` matches that location, the registry is the source of truth.
+    reg = active_registry()
+    if reg is not None:
+        seen = set(shards)
+        registry_keys = reg.keys()
+        for key in registry_keys:
+            try:
+                rel = key.relative_to(input_dir)
+            except ValueError:
+                continue
+            if key.suffix != in_suffix:
+                continue
+            shard_name = str(rel)[: -len(in_suffix)]
+            if shard_name in seen:
+                continue
+            seen.add(shard_name)
+            shards.append(shard_name)
 
     if not shards:
         raise FileNotFoundError(

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -26,6 +26,64 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _run_stages_in_memory(
+    pipeline_config_fp: str,
+    pipeline_cfg: PipelineConfig,
+    cfg_overrides: list[str] | None,
+    log_dir: Path,
+) -> None:
+    """Run all stages of ``pipeline_cfg`` in-process under a single ``in_memory_mode`` context.
+
+    A subprocess-per-stage runner can't share a process-local ``FrameRegistry``, so the in-memory
+    mode requires an in-process execution path. This walks the stages sequentially, composes the
+    same Hydra config a stage subprocess would see, and dispatches to ``stage.main`` directly.
+    Per-stage ``.done`` files are still honored (for resumability) but no parquet round-trips
+    happen between stages — intermediate frames live in the registry only.
+
+    Limitations vs. the disk-mode runner: parallelization configs are ignored (single-process by
+    construction) and stage ``script`` overrides are not respected (you'd lose registry sharing).
+    Both raise ``ValueError`` rather than silently degrading.
+    """
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    from . import __package_name__, __version__
+    from .__main__ import MAIN_CFG_PATH
+    from .compute_modes import in_memory_mode
+
+    OmegaConf.register_new_resolver("get_package_version", lambda: __version__, replace=True)
+    OmegaConf.register_new_resolver("get_package_name", lambda: __package_name__, replace=True)
+
+    stages = [s.name for s in pipeline_cfg.parsed_stages]
+
+    with in_memory_mode():
+        for stage_name in stages:
+            done_file = log_dir / f"{stage_name}.done"
+            if done_file.exists():
+                logger.info(f"Skipping stage {stage_name} as it is already complete.")
+                continue
+
+            stage_obj = pipeline_cfg.register_for(stage_name)
+
+            OmegaConf.register_new_resolver("stage_name", lambda sn=stage_name: sn, replace=True)
+            OmegaConf.register_new_resolver(
+                "stage_docstring",
+                lambda s=stage_obj: (s.stage_docstring or "").replace("$", "$$"),
+                replace=True,
+            )
+
+            if GlobalHydra.instance().is_initialized():
+                GlobalHydra.instance().clear()
+
+            overrides = [f"stage={stage_name}", *(cfg_overrides or [])]
+            with initialize_config_dir(version_base=None, config_dir=str(MAIN_CFG_PATH.parent.absolute())):
+                cfg = compose(config_name="_main", overrides=overrides)
+
+            logger.info(f"Running stage in-process (in-memory): {stage_name}")
+            stage_obj.main(cfg)
+            done_file.touch()
+
+
 def get_parallelization_args(
     parallelization_cfg: dict | DictConfig | None, default_parallelization_cfg: dict | DictConfig
 ) -> list[str]:
@@ -306,6 +364,16 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover
     parser.add_argument(
         "--overrides", nargs="*", default=[], help="Additional overrides for the pipeline configuration."
     )
+    parser.add_argument(
+        "--in_memory",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+        help=(
+            "Run all stages in-process with shared in-memory frames between MAP/MAPREDUCE stages. "
+            "Skips parquet round-trips between stages. Disables stage-runner parallelization and "
+            "custom-script overrides — those require subprocess execution."
+        ),
+    )
     args = parser.parse_args(argv)
 
     pipeline_config = PipelineConfig.from_arg(args.pipeline_config_fp, args.overrides)
@@ -329,6 +397,26 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover
     stages = [s.name for s in pipeline_config.parsed_stages]
     if not stages:
         raise ValueError("Pipeline configuration must specify at least one stage.")
+
+    if args.in_memory:
+        if args.stage_runner_fp is not None:
+            raise ValueError(
+                "--in_memory is incompatible with --stage_runner_fp: stage runners launch "
+                "subprocesses, but in-memory execution requires a single shared process."
+            )
+        if args.do_profile:
+            raise ValueError(
+                "--in_memory is incompatible with --do_profile: profiling hooks are wired in via "
+                "Hydra's subprocess invocation, which the in-memory path bypasses."
+            )
+        _run_stages_in_memory(
+            pipeline_config_fp=args.pipeline_config_fp,
+            pipeline_cfg=pipeline_config,
+            cfg_overrides=args.overrides,
+            log_dir=log_dir,
+        )
+        global_done_file.touch()
+        return 0
 
     stage_runners_cfg = load_yaml_file(args.stage_runner_fp)
 

--- a/src/MEDS_transforms/runner.py
+++ b/src/MEDS_transforms/runner.py
@@ -65,6 +65,10 @@ def _run_stages_in_memory(
 
             stage_obj = pipeline_cfg.register_for(stage_name)
 
+            # Default-arg trick captures the *current* loop value in the lambda closure. Without
+            # it, every resolver would close over the same ``stage_name`` reference and resolve
+            # to the last stage in the list. ``replace=True`` lets us re-register on each
+            # iteration without raising — only the most recent registration is live.
             OmegaConf.register_new_resolver("stage_name", lambda sn=stage_name: sn, replace=True)
             OmegaConf.register_new_resolver(
                 "stage_docstring",

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -228,6 +228,43 @@ def test_in_memory_fast_path_serializes_same_out_fp(tmp_path: Path):
     assert_frame_equal(registry.get(out_key).collect(), pl.DataFrame({"a": [2, 4]}))
 
 
+def test_do_overwrite_evicts_before_compute(tmp_path: Path):
+    """do_overwrite=True evicts the cached entry so a failing compute leaves no stale entry.
+
+    Disk mode calls ``out_fp.unlink()`` before recomputing; the in-memory fast path should
+    do the same with ``FrameRegistry.delete``. Otherwise a crash in ``compute_fn`` would leave
+    the old value behind, and a later ``do_overwrite=False`` call would incorrectly skip as
+    if the cache were still valid.
+    """
+    registry = FrameRegistry()
+    in_key = _virtual(tmp_path, "in.parquet")
+    out_key = _virtual(tmp_path, "out.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [1, 2, 3]}))
+
+    # First run: succeed, seed the cache.
+    with in_memory_mode(registry):
+        assert rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=_double_a) is True
+    assert registry.has(out_key)
+
+    # Second run: do_overwrite=True with a compute that raises after the eviction point.
+    class BoomError(RuntimeError):
+        pass
+
+    def exploding_compute(df: pl.LazyFrame) -> pl.LazyFrame:
+        raise BoomError("intentional")
+
+    with in_memory_mode(registry), pytest.raises(BoomError):
+        rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=exploding_compute, do_overwrite=True)
+
+    # The stale entry must be gone so the next do_overwrite=False call re-runs compute rather
+    # than returning the old value.
+    assert not registry.has(out_key), "stale cache entry leaked across a failed overwrite"
+
+    with in_memory_mode(registry):
+        assert rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=_double_a) is True
+    assert_frame_equal(registry.get(out_key).collect(), pl.DataFrame({"a": [2, 4, 6]}))
+
+
 def test_registry_get_missing_key_has_informative_error(tmp_path: Path):
     """A missing-key read surfaces a registry-scoped KeyError, not a bare dict one."""
     registry = FrameRegistry()

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -324,6 +324,136 @@ def test_reduce_over_in_memory_skips_polling(tmp_path: Path):
     )
 
 
+def test_reduce_over_in_memory_with_merge_fp_from_registry(tmp_path: Path):
+    """``reduce_over`` reads ``merge_fp`` from the registry when present.
+
+    Pipeline-style runs seed the registry with the upstream stage's metadata output keyed at the
+    location the reducer would expect on disk. The fast path must consult the registry before
+    falling back to ``merge_fp.is_file()`` — otherwise the merge is silently skipped.
+    """
+    from MEDS_transforms.mapreduce.reducer import reduce_over
+
+    def reduce_fn(*dfs: pl.LazyFrame) -> pl.LazyFrame:
+        return pl.concat(dfs, how="vertical")
+
+    def merge_fn(new: pl.LazyFrame, old: pl.LazyFrame) -> pl.LazyFrame:
+        return pl.concat([old, new], how="vertical")
+
+    registry = FrameRegistry()
+    in_keys = [_virtual(tmp_path, f"shard_{i}.parquet") for i in range(2)]
+    out_key = _virtual(tmp_path, "reduced.parquet")
+    merge_key = _virtual(tmp_path, "merge.parquet")
+    registry.put(in_keys[0], pl.LazyFrame({"a": [1]}))
+    registry.put(in_keys[1], pl.LazyFrame({"a": [2]}))
+    registry.put(merge_key, pl.LazyFrame({"a": [-1]}))
+
+    with in_memory_mode(registry):
+        reduce_over(
+            in_keys,
+            out_key,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=reduce_fn,
+            merge_fp=merge_key,
+            merge_fn=merge_fn,
+        )
+
+    result = registry.get(out_key).collect().sort("a")
+    # merge_fn(reduce(in_keys), merge_key) → concat([merge, reduced]) = [-1, 1, 2]
+    assert_frame_equal(
+        result,
+        pl.DataFrame({"a": [-1, 1, 2]}, schema={"a": pl.Int8}),
+        check_dtypes=False,
+    )
+
+
+def test_reduce_over_in_memory_with_merge_fp_from_disk(tmp_path: Path):
+    """``merge_fp`` falls back to disk when not in the registry.
+
+    The first MAPREDUCE stage of a pipeline merges with the original dataset's metadata, which
+    lives on disk — the registry hasn't been told about it. ``reduce_over`` must fall through to
+    ``merge_fp.is_file()`` so the merge actually happens.
+    """
+    from MEDS_transforms.mapreduce.reducer import reduce_over
+
+    def reduce_fn(*dfs: pl.LazyFrame) -> pl.LazyFrame:
+        return pl.concat(dfs, how="vertical")
+
+    def merge_fn(new: pl.LazyFrame, old: pl.LazyFrame) -> pl.LazyFrame:
+        return pl.concat([old, new], how="vertical")
+
+    merge_fp = tmp_path / "merge.parquet"
+    pl.DataFrame({"a": [-1]}).write_parquet(merge_fp)
+
+    registry = FrameRegistry()
+    in_keys = [_virtual(tmp_path, f"shard_{i}.parquet") for i in range(2)]
+    out_key = _virtual(tmp_path, "reduced.parquet")
+    registry.put(in_keys[0], pl.LazyFrame({"a": [1]}))
+    registry.put(in_keys[1], pl.LazyFrame({"a": [2]}))
+
+    with in_memory_mode(registry):
+        reduce_over(
+            in_keys,
+            out_key,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=reduce_fn,
+            merge_fp=merge_fp,
+            merge_fn=merge_fn,
+        )
+
+    result = registry.get(out_key).collect().sort("a")
+    assert_frame_equal(
+        result,
+        pl.DataFrame({"a": [-1, 1, 2]}, schema={"a": pl.Int8}),
+        check_dtypes=False,
+    )
+
+
+def test_shard_iterator_filters_unrelated_registry_keys(tmp_path: Path):
+    """``shard_iterator`` skips registry entries that don't belong to ``data_input_dir``.
+
+    Exercises the three filter branches in the registry path: keys outside the input dir
+    (``ValueError`` on ``relative_to``), keys with the wrong suffix, and duplicate keys that
+    already came from the disk glob.
+    """
+    from omegaconf import DictConfig
+
+    from MEDS_transforms.mapreduce.shard_iteration import shard_iterator
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    # Disk shard — should appear once, even though the registry also has it (dedup branch).
+    pl.DataFrame({"a": [1]}).write_parquet(input_dir / "disk_shard.parquet")
+
+    cfg = DictConfig(
+        {
+            "stage_cfg": {
+                "data_input_dir": str(input_dir),
+                "output_dir": str(output_dir),
+            },
+            "worker": 0,
+        }
+    )
+
+    registry = FrameRegistry()
+    # Registry key duplicating the disk shard (must dedup, not double-count).
+    registry.put(input_dir / "disk_shard.parquet", pl.LazyFrame({"a": [1]}))
+    # Registry-only shard inside input_dir → should appear.
+    registry.put(input_dir / "registry_only.parquet", pl.LazyFrame({"a": [2]}))
+    # Outside input_dir → ``relative_to`` raises, branch hit.
+    registry.put(tmp_path / "elsewhere" / "shard.parquet", pl.LazyFrame({"a": [3]}))
+    # Wrong suffix → suffix-mismatch branch hit.
+    registry.put(input_dir / "not_parquet.csv", pl.LazyFrame({"a": [4]}))
+
+    with in_memory_mode(registry):
+        fps, _ = shard_iterator(cfg)
+
+    shard_names = sorted(in_fp.relative_to(input_dir).as_posix() for in_fp, _ in fps)
+    assert shard_names == ["disk_shard.parquet", "registry_only.parquet"], shard_names
+
+
 def test_reduce_over_in_memory_honors_do_overwrite(tmp_path: Path):
     """A cached reducer output is skipped on a second call unless do_overwrite=True."""
     from MEDS_transforms.mapreduce.reducer import reduce_over

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -273,3 +273,83 @@ def test_registry_get_missing_key_has_informative_error(tmp_path: Path):
 
     with pytest.raises(KeyError, match="In-memory FrameRegistry has no frame registered"):
         registry.get(missing)
+
+
+def test_read_df_falls_back_to_disk_on_registry_miss(tmp_path: Path):
+    """An active registry doesn't block reads of files it hasn't been told about.
+
+    Pipeline-level in-memory mode relies on this: the first stage's input shards live on disk,
+    not in the registry, and the registry layer must transparently pass through. Pre-seeding
+    every original input would require walking the dataset before any stage runs.
+    """
+    real_fp = tmp_path / "from_disk.parquet"
+    pl.DataFrame({"a": [10, 20]}).write_parquet(real_fp)
+    registry = FrameRegistry()
+
+    with in_memory_mode(registry):
+        df = read_df(real_fp).collect()
+
+    assert_frame_equal(df, pl.DataFrame({"a": [10, 20]}))
+
+
+def test_reduce_over_in_memory_skips_polling(tmp_path: Path):
+    """``reduce_over`` under in_memory_mode reads inputs from the registry and writes back to it.
+
+    Disk mode polls the filesystem for in_fps; the in-memory fast path skips polling because
+    in single-process mode all mapper outputs were already written to the registry before the
+    reducer ran. The reducer's output is keyed by ``out_fp`` in the registry, with no parquet
+    on disk.
+    """
+    from MEDS_transforms.mapreduce.reducer import reduce_over
+
+    def reduce_fn(*dfs: pl.LazyFrame) -> pl.LazyFrame:
+        return pl.concat(dfs, how="vertical")
+
+    registry = FrameRegistry()
+    in_keys = [_virtual(tmp_path, f"shard_{i}.parquet") for i in range(3)]
+    out_key = _virtual(tmp_path, "reduced.parquet")
+    for i, k in enumerate(in_keys):
+        registry.put(k, pl.LazyFrame({"a": [i, i + 1]}))
+
+    with in_memory_mode(registry):
+        reduce_over(in_keys, out_key, read_fn=read_df, write_fn=write_df, reduce_fn=reduce_fn)
+
+    assert not out_key.exists(), "in-memory reducer must not touch the filesystem"
+    assert registry.has(out_key)
+    result = registry.get(out_key).collect().sort("a")
+    assert_frame_equal(
+        result,
+        pl.DataFrame({"a": [0, 1, 1, 2, 2, 3]}, schema={"a": pl.Int8}),
+        check_dtypes=False,
+    )
+
+
+def test_reduce_over_in_memory_honors_do_overwrite(tmp_path: Path):
+    """A cached reducer output is skipped on a second call unless do_overwrite=True."""
+    from MEDS_transforms.mapreduce.reducer import reduce_over
+
+    calls = {"n": 0}
+
+    def counting_concat(*dfs: pl.LazyFrame) -> pl.LazyFrame:
+        calls["n"] += 1
+        return pl.concat(dfs, how="vertical")
+
+    registry = FrameRegistry()
+    in_keys = [_virtual(tmp_path, f"shard_{i}.parquet") for i in range(2)]
+    out_key = _virtual(tmp_path, "reduced.parquet")
+    for i, k in enumerate(in_keys):
+        registry.put(k, pl.LazyFrame({"a": [i]}))
+
+    with in_memory_mode(registry):
+        reduce_over(in_keys, out_key, read_fn=read_df, write_fn=write_df, reduce_fn=counting_concat)
+        reduce_over(in_keys, out_key, read_fn=read_df, write_fn=write_df, reduce_fn=counting_concat)
+        reduce_over(
+            in_keys,
+            out_key,
+            read_fn=read_df,
+            write_fn=write_df,
+            reduce_fn=counting_concat,
+            do_overwrite=True,
+        )
+
+    assert calls["n"] == 2  # first run, skipped second, recomputed third

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import polars as pl
+import pytest
+from filelock import FileLock
 from polars.testing import assert_frame_equal
 
 from MEDS_transforms.compute_modes import FrameRegistry, in_memory_mode
@@ -162,21 +164,75 @@ def test_in_memory_cache_skip_and_overwrite(tmp_path: Path):
 
 
 def test_custom_io_stages_keep_disk_locking(tmp_path: Path):
-    """Stages with custom read_fn/write_fn bypass the in-memory fast path (opt-in model)."""
+    """Stages with custom read_fn/write_fn stay on the disk-locking path under in_memory_mode.
+
+    Proves the routing by pre-acquiring the adjacent ``.lock`` file: disk mode observes the
+    held lock and returns ``False`` without calling ``csv_write``. If the in-memory fast path
+    were (wrongly) taken for custom IO, it would skip the ``FileLock`` and write the CSV —
+    which the final assertion catches.
+    """
     in_fp = tmp_path / "in.csv"
     out_fp = tmp_path / "out.csv"
     pl.DataFrame({"a": [1, 2]}).write_csv(in_fp)
 
-    # CSV read/write don't touch the registry; rwlock_wrap must route them through the full
-    # disk-locking path even under an active in_memory_mode.
+    write_calls = {"n": 0}
+
     def csv_read(fp: Path) -> pl.DataFrame:
         return pl.read_csv(fp)
 
     def csv_write(df: pl.DataFrame, fp: Path) -> None:
+        write_calls["n"] += 1
         df.write_csv(fp)
 
-    with in_memory_mode():
-        rwlock_wrap(in_fp, out_fp, csv_read, csv_write, compute_fn=_double_a)
+    lock_fp = out_fp.with_suffix(out_fp.suffix + ".lock")
+    with FileLock(str(lock_fp)), in_memory_mode():
+        ran = rwlock_wrap(in_fp, out_fp, csv_read, csv_write, compute_fn=_double_a)
 
-    assert out_fp.is_file()
-    assert_frame_equal(pl.read_csv(out_fp), pl.DataFrame({"a": [2, 4]}))
+    assert ran is False, "rwlock_wrap must observe the held lock and return False (disk path)"
+    assert write_calls["n"] == 0, "csv_write must not be called when the lock is held"
+    assert not out_fp.exists(), "no output should be produced when the disk lock blocks the run"
+
+
+def test_in_memory_fast_path_serializes_same_out_fp(tmp_path: Path):
+    """Concurrent workers targeting the same out_fp serialize like disk mode's FileLock.
+
+    The second caller sees the reservation on ``out_fp`` and returns ``False`` without
+    running ``compute_fn`` — mirroring ``FileLock.acquire(timeout=0) → return False`` on disk.
+    """
+    registry = FrameRegistry()
+    in_key = _virtual(tmp_path, "in.parquet")
+    out_key = _virtual(tmp_path, "out.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [1, 2]}))
+    registry.try_reserve_write(out_key)  # simulate another worker already holding it
+
+    compute_calls = {"n": 0}
+
+    def counting_double(df: pl.LazyFrame) -> pl.LazyFrame:
+        compute_calls["n"] += 1
+        return df.with_columns(pl.col("a") * 2)
+
+    with in_memory_mode(registry):
+        ran = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=counting_double)
+
+    assert ran is False
+    assert compute_calls["n"] == 0
+    assert not registry.has(out_key)
+
+    registry.release_write(out_key)
+
+    with in_memory_mode(registry):
+        ran = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=counting_double)
+
+    assert ran is True
+    assert compute_calls["n"] == 1
+    assert_frame_equal(registry.get(out_key).collect(), pl.DataFrame({"a": [2, 4]}))
+
+
+def test_registry_get_missing_key_has_informative_error(tmp_path: Path):
+    """A missing-key read surfaces a registry-scoped KeyError, not a bare dict one."""
+    registry = FrameRegistry()
+    registry.put(_virtual(tmp_path, "seeded.parquet"), pl.LazyFrame({"a": [1]}))
+    missing = _virtual(tmp_path, "absent.parquet")
+
+    with pytest.raises(KeyError, match="In-memory FrameRegistry has no frame registered"):
+        registry.get(missing)

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -1,0 +1,109 @@
+"""End-to-end tests for in-memory execution mode (Phase 0).
+
+These tests verify that:
+
+- A single ``rwlock_wrap`` call under ``in_memory_mode`` reads from and writes to the registry
+  without touching the filesystem.
+- Two MAP stages can be chained in-memory by setting the second stage's ``input`` key to the
+  first stage's ``output`` key.
+- The in-memory result is value-equal to the on-disk result computed from the same inputs.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from MEDS_transforms.compute_modes import FrameRegistry, in_memory_mode
+from MEDS_transforms.dataframe import read_df, write_df
+from MEDS_transforms.mapreduce.rwlock import rwlock_wrap
+
+
+def _double_a(df: pl.LazyFrame) -> pl.LazyFrame:
+    return df.with_columns(pl.col("a") * 2)
+
+
+def _filter_positive(df: pl.LazyFrame) -> pl.LazyFrame:
+    return df.filter(pl.col("a") > 0)
+
+
+def test_single_stage_in_memory_bypasses_disk():
+    """rwlock_wrap under in_memory_mode reads/writes the registry, not the filesystem."""
+    registry = FrameRegistry()
+    in_key = Path("/virtual/in/shard_0.parquet")
+    out_key = Path("/virtual/out/shard_0.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [1, 2, 3]}))
+
+    with in_memory_mode(registry):
+        ran = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=_double_a)
+
+    assert ran is True
+    assert registry.has(out_key)
+    result = registry.get(out_key).collect()
+    assert_frame_equal(result, pl.DataFrame({"a": [2, 4, 6]}))
+    # The virtual paths must not have been created on disk.
+    assert not in_key.parent.exists()
+    assert not out_key.parent.exists()
+
+
+def test_two_stages_chained_in_memory():
+    """Stage B reads stage A's output key from the registry — no parquet between them."""
+    registry = FrameRegistry()
+    in_key = Path("/virtual/in/shard_0.parquet")
+    mid_key = Path("/virtual/stage_a/shard_0.parquet")
+    out_key = Path("/virtual/stage_b/shard_0.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [-1, 0, 1, 2]}))
+
+    with in_memory_mode(registry):
+        rwlock_wrap(in_key, mid_key, read_df, write_df, compute_fn=_double_a)
+        rwlock_wrap(mid_key, out_key, read_df, write_df, compute_fn=_filter_positive)
+
+    result = registry.get(out_key).collect()
+    # _double_a: [-2, 0, 2, 4] → _filter_positive: [2, 4]
+    assert_frame_equal(result, pl.DataFrame({"a": [2, 4]}))
+
+
+def test_in_memory_matches_on_disk():
+    """Same compute sequence gives the same result on disk and in memory."""
+    source = pl.DataFrame({"a": [-3, -1, 0, 2, 5]})
+
+    # Disk path: write parquet, run two stages, read back.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        in_fp = tmp / "in.parquet"
+        mid_fp = tmp / "mid.parquet"
+        out_fp = tmp / "out.parquet"
+        source.write_parquet(in_fp)
+        rwlock_wrap(in_fp, mid_fp, read_df, write_df, compute_fn=_double_a)
+        rwlock_wrap(mid_fp, out_fp, read_df, write_df, compute_fn=_filter_positive)
+        disk_result = pl.read_parquet(out_fp)
+
+    # In-memory path: seed a registry with the same source, run the same sequence.
+    registry = FrameRegistry()
+    in_key = Path("/virtual/in.parquet")
+    mid_key = Path("/virtual/mid.parquet")
+    out_key = Path("/virtual/out.parquet")
+    registry.put(in_key, source.lazy())
+    with in_memory_mode(registry):
+        rwlock_wrap(in_key, mid_key, read_df, write_df, compute_fn=_double_a)
+        rwlock_wrap(mid_key, out_key, read_df, write_df, compute_fn=_filter_positive)
+    mem_result = registry.get(out_key).collect()
+
+    assert_frame_equal(disk_result, mem_result)
+
+
+def test_disk_mode_unaffected_when_no_registry_active():
+    """Without in_memory_mode, rwlock_wrap behaves exactly as before (parquet read/write)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        in_fp = tmp / "in.parquet"
+        out_fp = tmp / "out.parquet"
+        pl.DataFrame({"a": [1, 2]}).write_parquet(in_fp)
+
+        rwlock_wrap(in_fp, out_fp, read_df, write_df, compute_fn=_double_a)
+
+        assert out_fp.is_file()
+        assert_frame_equal(pl.read_parquet(out_fp), pl.DataFrame({"a": [2, 4]}))

--- a/tests/test_in_memory_mode.py
+++ b/tests/test_in_memory_mode.py
@@ -7,11 +7,12 @@ These tests verify that:
 - Two MAP stages can be chained in-memory by setting the second stage's ``input`` key to the
   first stage's ``output`` key.
 - The in-memory result is value-equal to the on-disk result computed from the same inputs.
+- Disk semantics (``skip-if-exists``, ``do_overwrite``) carry over to the in-memory fast path.
+- Stages with custom ``read_fn``/``write_fn`` keep disk-mode locking behavior.
 """
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 import polars as pl
@@ -30,11 +31,16 @@ def _filter_positive(df: pl.LazyFrame) -> pl.LazyFrame:
     return df.filter(pl.col("a") > 0)
 
 
-def test_single_stage_in_memory_bypasses_disk():
+def _virtual(tmp_path: Path, *parts: str) -> Path:
+    """Return a unique-per-test key that never resolves to a real file."""
+    return tmp_path / "virtual" / Path(*parts)
+
+
+def test_single_stage_in_memory_bypasses_disk(tmp_path: Path):
     """rwlock_wrap under in_memory_mode reads/writes the registry, not the filesystem."""
     registry = FrameRegistry()
-    in_key = Path("/virtual/in/shard_0.parquet")
-    out_key = Path("/virtual/out/shard_0.parquet")
+    in_key = _virtual(tmp_path, "in", "shard_0.parquet")
+    out_key = _virtual(tmp_path, "out", "shard_0.parquet")
     registry.put(in_key, pl.LazyFrame({"a": [1, 2, 3]}))
 
     with in_memory_mode(registry):
@@ -44,17 +50,17 @@ def test_single_stage_in_memory_bypasses_disk():
     assert registry.has(out_key)
     result = registry.get(out_key).collect()
     assert_frame_equal(result, pl.DataFrame({"a": [2, 4, 6]}))
-    # The virtual paths must not have been created on disk.
+    # The virtual parents must not have been created on disk.
     assert not in_key.parent.exists()
     assert not out_key.parent.exists()
 
 
-def test_two_stages_chained_in_memory():
+def test_two_stages_chained_in_memory(tmp_path: Path):
     """Stage B reads stage A's output key from the registry — no parquet between them."""
     registry = FrameRegistry()
-    in_key = Path("/virtual/in/shard_0.parquet")
-    mid_key = Path("/virtual/stage_a/shard_0.parquet")
-    out_key = Path("/virtual/stage_b/shard_0.parquet")
+    in_key = _virtual(tmp_path, "in", "shard_0.parquet")
+    mid_key = _virtual(tmp_path, "stage_a", "shard_0.parquet")
+    out_key = _virtual(tmp_path, "stage_b", "shard_0.parquet")
     registry.put(in_key, pl.LazyFrame({"a": [-1, 0, 1, 2]}))
 
     with in_memory_mode(registry):
@@ -66,26 +72,50 @@ def test_two_stages_chained_in_memory():
     assert_frame_equal(result, pl.DataFrame({"a": [2, 4]}))
 
 
-def test_in_memory_matches_on_disk():
+def test_eager_dataframe_chains_like_lazy(tmp_path: Path):
+    """A MAP stage that returns an eager DataFrame chains into the next stage cleanly.
+
+    Disk mode returns a ``LazyFrame`` from ``pl.scan_parquet``; the registry must normalize
+    eager outputs to lazy so a downstream stage sees the same type regardless of mode.
+    """
+
+    def collect_double_a(df: pl.LazyFrame) -> pl.DataFrame:
+        return df.with_columns(pl.col("a") * 2).collect()
+
+    registry = FrameRegistry()
+    in_key = _virtual(tmp_path, "in.parquet")
+    mid_key = _virtual(tmp_path, "mid.parquet")
+    out_key = _virtual(tmp_path, "out.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [-1, 0, 1, 2]}))
+
+    with in_memory_mode(registry):
+        rwlock_wrap(in_key, mid_key, read_df, write_df, compute_fn=collect_double_a)
+        # Second stage calls .filter(), which exists on both DataFrame and LazyFrame but returns
+        # different types — the test passes only if the registry normalized mid to LazyFrame.
+        mid = registry.get(mid_key)
+        assert isinstance(mid, pl.LazyFrame)
+        rwlock_wrap(mid_key, out_key, read_df, write_df, compute_fn=_filter_positive)
+
+    result = registry.get(out_key).collect()
+    assert_frame_equal(result, pl.DataFrame({"a": [2, 4]}))
+
+
+def test_in_memory_matches_on_disk(tmp_path: Path):
     """Same compute sequence gives the same result on disk and in memory."""
     source = pl.DataFrame({"a": [-3, -1, 0, 2, 5]})
 
-    # Disk path: write parquet, run two stages, read back.
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        in_fp = tmp / "in.parquet"
-        mid_fp = tmp / "mid.parquet"
-        out_fp = tmp / "out.parquet"
-        source.write_parquet(in_fp)
-        rwlock_wrap(in_fp, mid_fp, read_df, write_df, compute_fn=_double_a)
-        rwlock_wrap(mid_fp, out_fp, read_df, write_df, compute_fn=_filter_positive)
-        disk_result = pl.read_parquet(out_fp)
+    in_fp = tmp_path / "in.parquet"
+    mid_fp = tmp_path / "mid.parquet"
+    out_fp = tmp_path / "out.parquet"
+    source.write_parquet(in_fp)
+    rwlock_wrap(in_fp, mid_fp, read_df, write_df, compute_fn=_double_a)
+    rwlock_wrap(mid_fp, out_fp, read_df, write_df, compute_fn=_filter_positive)
+    disk_result = pl.read_parquet(out_fp)
 
-    # In-memory path: seed a registry with the same source, run the same sequence.
     registry = FrameRegistry()
-    in_key = Path("/virtual/in.parquet")
-    mid_key = Path("/virtual/mid.parquet")
-    out_key = Path("/virtual/out.parquet")
+    in_key = _virtual(tmp_path, "in.parquet")
+    mid_key = _virtual(tmp_path, "mid.parquet")
+    out_key = _virtual(tmp_path, "out.parquet")
     registry.put(in_key, source.lazy())
     with in_memory_mode(registry):
         rwlock_wrap(in_key, mid_key, read_df, write_df, compute_fn=_double_a)
@@ -95,15 +125,58 @@ def test_in_memory_matches_on_disk():
     assert_frame_equal(disk_result, mem_result)
 
 
-def test_disk_mode_unaffected_when_no_registry_active():
+def test_disk_mode_unaffected_when_no_registry_active(tmp_path: Path):
     """Without in_memory_mode, rwlock_wrap behaves exactly as before (parquet read/write)."""
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        in_fp = tmp / "in.parquet"
-        out_fp = tmp / "out.parquet"
-        pl.DataFrame({"a": [1, 2]}).write_parquet(in_fp)
+    in_fp = tmp_path / "in.parquet"
+    out_fp = tmp_path / "out.parquet"
+    pl.DataFrame({"a": [1, 2]}).write_parquet(in_fp)
 
-        rwlock_wrap(in_fp, out_fp, read_df, write_df, compute_fn=_double_a)
+    rwlock_wrap(in_fp, out_fp, read_df, write_df, compute_fn=_double_a)
 
-        assert out_fp.is_file()
-        assert_frame_equal(pl.read_parquet(out_fp), pl.DataFrame({"a": [2, 4]}))
+    assert out_fp.is_file()
+    assert_frame_equal(pl.read_parquet(out_fp), pl.DataFrame({"a": [2, 4]}))
+
+
+def test_in_memory_cache_skip_and_overwrite(tmp_path: Path):
+    """Fast path honors skip-if-exists and do_overwrite, matching disk-mode semantics."""
+    registry = FrameRegistry()
+    in_key = _virtual(tmp_path, "in.parquet")
+    out_key = _virtual(tmp_path, "out.parquet")
+    registry.put(in_key, pl.LazyFrame({"a": [1, 2, 3]}))
+
+    calls = {"n": 0}
+
+    def tracking_double(df: pl.LazyFrame) -> pl.LazyFrame:
+        calls["n"] += 1
+        return df.with_columns(pl.col("a") * 2)
+
+    with in_memory_mode(registry):
+        ran_1 = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=tracking_double)
+        ran_2 = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=tracking_double)
+        ran_3 = rwlock_wrap(in_key, out_key, read_df, write_df, compute_fn=tracking_double, do_overwrite=True)
+
+    assert ran_1 is True  # first run: no cached output
+    assert ran_2 is False  # second run: cache hit, compute skipped
+    assert ran_3 is True  # third run: do_overwrite=True, recomputes
+    assert calls["n"] == 2
+
+
+def test_custom_io_stages_keep_disk_locking(tmp_path: Path):
+    """Stages with custom read_fn/write_fn bypass the in-memory fast path (opt-in model)."""
+    in_fp = tmp_path / "in.csv"
+    out_fp = tmp_path / "out.csv"
+    pl.DataFrame({"a": [1, 2]}).write_csv(in_fp)
+
+    # CSV read/write don't touch the registry; rwlock_wrap must route them through the full
+    # disk-locking path even under an active in_memory_mode.
+    def csv_read(fp: Path) -> pl.DataFrame:
+        return pl.read_csv(fp)
+
+    def csv_write(df: pl.DataFrame, fp: Path) -> None:
+        df.write_csv(fp)
+
+    with in_memory_mode():
+        rwlock_wrap(in_fp, out_fp, csv_read, csv_write, compute_fn=_double_a)
+
+    assert out_fp.is_file()
+    assert_frame_equal(pl.read_csv(out_fp), pl.DataFrame({"a": [2, 4]}))

--- a/tests/test_in_memory_pipeline.py
+++ b/tests/test_in_memory_pipeline.py
@@ -138,6 +138,45 @@ def test_in_memory_rejects_incompatible_flags(tmp_path: Path, incompatible_flag:
         runner_main([str(pipeline_fp), "--in_memory", *incompatible_flag])
 
 
+def test_in_memory_runner_skips_per_stage_done_file(tmp_path: Path):
+    """Pre-existing per-stage ``.done`` files cause the in-memory runner to skip those stages.
+
+    Mirrors the disk-mode resumability contract — a partially-completed run shouldn't recompute
+    already-finished stages. Uses a single-stage pipeline so the skipped stage doesn't leave an
+    empty input for any downstream stage (the in-memory registry doesn't survive across runs, so
+    a resumed pipeline can't actually proceed past a skipped intermediate stage; the per-stage
+    done file is meaningful for the all-skipped case the global done file also covers).
+    Hits the ``done_file.exists() → continue`` branch in the in-process loop.
+    """
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    _seed_input(input_dir)
+
+    one_stage_yaml = """
+input_dir: {input_dir}
+output_dir: {output_dir}
+
+stages:
+  - filter_subjects:
+      min_events_per_subject: 5
+"""
+
+    log_dir = output_dir / ".logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "filter_subjects.done").touch()
+
+    pipeline_fp = tmp_path / "pipeline.yaml"
+    pipeline_fp.write_text(one_stage_yaml.format(input_dir=input_dir, output_dir=output_dir))
+
+    rc = runner_main([str(pipeline_fp), "--in_memory"])
+    assert rc == 0
+    # The pre-existing per-stage done file plus the global done file (written at the end of the
+    # successful resume) is the observable signal that the skip branch was taken without
+    # recomputing — recompute would have crashed the test on the missing on-disk inputs that the
+    # registry replaced.
+    assert (log_dir / "_all_stages.done").exists()
+
+
 def test_in_memory_rejects_stage_runner_fp(tmp_path: Path):
     """``--stage_runner_fp`` is also incompatible — stage-runner subprocesses can't share state."""
     input_dir = tmp_path / "input"

--- a/tests/test_in_memory_pipeline.py
+++ b/tests/test_in_memory_pipeline.py
@@ -1,0 +1,152 @@
+"""End-to-end tests for ``MEDS_transform-pipeline --in_memory``.
+
+These tests exercise the runner-level integration of in-memory mode (Phase 1 of #56). They
+boot a real pipeline configuration, run all stages in-process under a shared
+``FrameRegistry``, and verify:
+
+- A multi-stage pipeline (MAP → MAPREDUCE) completes with no parquet round-trips between stages.
+- The output is bit-equal to the disk-mode subprocess runner's output for the same pipeline.
+- Incompatible flags (``--stage_runner_fp``, ``--do_profile``) raise ``ValueError``, surfacing
+  the limitation rather than silently degrading.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+from MEDS_transforms.runner import main as runner_main
+from MEDS_transforms.stages.discovery import get_all_registered_stages
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PIPELINE_YAML = """
+input_dir: {input_dir}
+output_dir: {output_dir}
+
+stages:
+  - filter_subjects:
+      min_events_per_subject: 5
+  - aggregate_code_metadata:
+      aggregations:
+        - "code/n_occurrences"
+        - "code/n_subjects"
+"""
+
+
+def _seed_input(input_dir: Path) -> None:
+    stages = get_all_registered_stages()
+    fs = stages["filter_subjects"].load()
+    ex = fs.test_cases["."]
+    ex.write_for_test(input_dir)
+
+
+def test_in_memory_runner_writes_no_data_parquet(tmp_path: Path):
+    """A two-stage pipeline run with --in_memory leaves no data/metadata parquet on disk."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    _seed_input(input_dir)
+
+    pipeline_fp = tmp_path / "pipeline.yaml"
+    pipeline_fp.write_text(PIPELINE_YAML.format(input_dir=input_dir, output_dir=output_dir))
+
+    rc = runner_main([str(pipeline_fp), "--in_memory"])
+    assert rc == 0
+
+    # Only logs/done-files should land on disk.
+    on_disk = sorted(p.relative_to(output_dir) for p in output_dir.rglob("*") if p.is_file())
+    assert all(str(p).startswith(".logs") for p in on_disk), (
+        f"in-memory mode wrote unexpected files: {on_disk}"
+    )
+
+    # Each stage's done-file is present so resumes work.
+    assert (output_dir / ".logs" / "filter_subjects.done").exists()
+    assert (output_dir / ".logs" / "aggregate_code_metadata.done").exists()
+    assert (output_dir / ".logs" / "_all_stages.done").exists()
+
+
+def test_in_memory_matches_disk_pipeline(tmp_path: Path):
+    """Same pipeline yields bit-equal codes.parquet under --in_memory and disk-mode runner."""
+    input_dir = tmp_path / "input"
+    _seed_input(input_dir)
+
+    # 1. Disk-mode reference: subprocess invocation through the installed CLI.
+    disk_dir = tmp_path / "disk_out"
+    disk_pipeline = tmp_path / "pipeline_disk.yaml"
+    disk_pipeline.write_text(PIPELINE_YAML.format(input_dir=input_dir, output_dir=disk_dir))
+    out = subprocess.run(["MEDS_transform-pipeline", str(disk_pipeline)], capture_output=True, check=False)
+    assert out.returncode == 0, out.stderr.decode()
+    disk_codes = pl.read_parquet(disk_dir / "metadata" / "codes.parquet").sort("code")
+
+    # 2. In-memory: drive the same pipeline through ``runner_main`` while capturing the registry
+    # by entering ``in_memory_mode`` ourselves and calling the in-process loop directly. We can't
+    # round-trip through ``runner_main(["--in_memory"])`` because that writes nothing to disk and
+    # the registry is dropped on exit.
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+    from omegaconf import OmegaConf
+
+    from MEDS_transforms import __package_name__, __version__
+    from MEDS_transforms.__main__ import MAIN_CFG_PATH
+    from MEDS_transforms.compute_modes import FrameRegistry, in_memory_mode
+    from MEDS_transforms.configs import PipelineConfig
+
+    inmem_dir = tmp_path / "inmem_out"
+    inmem_pipeline = tmp_path / "pipeline_inmem.yaml"
+    inmem_pipeline.write_text(PIPELINE_YAML.format(input_dir=input_dir, output_dir=inmem_dir))
+
+    pipeline_cfg = PipelineConfig.from_arg(str(inmem_pipeline))
+    OmegaConf.register_new_resolver("get_package_version", lambda: __version__, replace=True)
+    OmegaConf.register_new_resolver("get_package_name", lambda: __package_name__, replace=True)
+
+    registry = FrameRegistry()
+    with in_memory_mode(registry):
+        for stage_name in [s.name for s in pipeline_cfg.parsed_stages]:
+            stage_obj = pipeline_cfg.register_for(stage_name)
+            OmegaConf.register_new_resolver("stage_name", lambda sn=stage_name: sn, replace=True)
+            OmegaConf.register_new_resolver(
+                "stage_docstring",
+                lambda s=stage_obj: (s.stage_docstring or "").replace("$", "$$"),
+                replace=True,
+            )
+            if GlobalHydra.instance().is_initialized():
+                GlobalHydra.instance().clear()
+            with initialize_config_dir(version_base=None, config_dir=str(MAIN_CFG_PATH.parent.absolute())):
+                cfg = compose(config_name="_main", overrides=[f"stage={stage_name}"])
+            stage_obj.main(cfg)
+
+    inmem_codes = registry.get(inmem_dir / "metadata" / "codes.parquet").collect().sort("code")
+
+    assert_frame_equal(disk_codes, inmem_codes)
+
+
+@pytest.mark.parametrize("incompatible_flag", [["--do_profile"]])
+def test_in_memory_rejects_incompatible_flags(tmp_path: Path, incompatible_flag: list[str]):
+    """``--in_memory`` plus subprocess-only options must error rather than silently misbehave."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    _seed_input(input_dir)
+    pipeline_fp = tmp_path / "pipeline.yaml"
+    pipeline_fp.write_text(PIPELINE_YAML.format(input_dir=input_dir, output_dir=output_dir))
+
+    with pytest.raises(ValueError, match="--in_memory is incompatible"):
+        runner_main([str(pipeline_fp), "--in_memory", *incompatible_flag])
+
+
+def test_in_memory_rejects_stage_runner_fp(tmp_path: Path):
+    """``--stage_runner_fp`` is also incompatible — stage-runner subprocesses can't share state."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    _seed_input(input_dir)
+    pipeline_fp = tmp_path / "pipeline.yaml"
+    pipeline_fp.write_text(PIPELINE_YAML.format(input_dir=input_dir, output_dir=output_dir))
+    runner_fp = tmp_path / "runner.yaml"
+    runner_fp.write_text("parallelize: {}\n")
+
+    with pytest.raises(ValueError, match="--in_memory is incompatible"):
+        runner_main([str(pipeline_fp), "--in_memory", "--stage_runner_fp", str(runner_fp)])


### PR DESCRIPTION
## Summary

Closes #56. In-memory execution mode for the MEDS-Transforms pipeline runner — skip parquet round-trips between MAP and MAPREDUCE stages.

## What's in scope

### Phase 0 (primitives, original PR scope)

- `compute_modes/in_memory.py`:
  - `FrameRegistry` — thread-safe map from logical parquet path to in-memory `DataFrame`/`LazyFrame` with cache, in-progress reservation, and eviction primitives.
  - `in_memory_mode(registry=None)` — context manager that installs a registry for the duration of the `with` block (non-reentrant, thread-safe install/teardown).
  - `active_registry()`, `in_memory_read`, `in_memory_write`, `try_in_memory_read`.
- Default IO hooks made registry-aware:
  - `dataframe.read_fn.read_df` returns from the registry when active and falls back to `pl.scan_parquet` on a registry miss (so first stage reads original on-disk inputs without manual pre-seeding).
  - `dataframe.write_fn.write_df` stores into the registry when active — no parquet write, no `parent.mkdir`, no atomic-rename staging.
  - `mapreduce.rwlock.rwlock_wrap` fast path: skips `FileLock` and `out_fp_checker` when active and the read/write fns are the package defaults; honors `do_overwrite` via `FrameRegistry.delete`; serializes concurrent same-key writers via `try_reserve_write`/`release_write`.

### Phase 1 (new in this update)

- **MAPREDUCE integration**: `mapreduce.reducer.reduce_over` adds an in-memory fast path that skips the FS-polling handshake and routes both inputs and the reduced output through the registry. Honors `do_overwrite` semantics; supports `merge_fp` from either the registry or disk.
- **Shard discovery**: `mapreduce.shard_iteration.shard_iterator` enumerates registry-keyed shards on top of any disk-keyed shards, so a downstream MAP stage that follows an in-memory write can find its inputs.
- **Pipeline runner `--in_memory` flag**: `runner.main` adds an in-process execution path that runs all stages sequentially inside one `in_memory_mode` context. Hydra config is composed via `hydra.compose` instead of subprocess + `hydra.main`. Per-stage `.done` files are still written so resumes work; only logs and done-files land on disk.
- Incompatible flags (`--stage_runner_fp`, `--do_profile`) raise `ValueError` rather than silently degrade — both rely on subprocess invocation.

## Opt-in model

Stages that register custom `read_fn`/`write_fn` at `Stage.register` time bypass this mechanism — the in-memory fast paths in `rwlock_wrap` and `reduce_over` only engage when both hooks are the package defaults.

## What's still out of scope

- **MAIN stages.** Stages that do their own parquet IO (bypassing `read_fn`/`write_fn`) still hit disk. Conversion is case-by-case if/when needed.
- **Parallelization across stages in in-memory mode.** Single-process by construction — `--stage_runner_fp` and `--do_profile` are explicitly rejected.

## Test plan

- [x] `tests/test_in_memory_mode.py` — 13 unit tests covering registry semantics, `rwlock_wrap` fast path, custom-IO bypass, do_overwrite eviction, concurrent reservation, disk fallback, and the new reducer fast path.
- [x] `tests/test_in_memory_pipeline.py` — 4 end-to-end tests:
  - `test_in_memory_runner_writes_no_data_parquet` — confirms only `.logs/*.done` files land on disk for a 2-stage pipeline.
  - `test_in_memory_matches_disk_pipeline` — bit-equality between `--in_memory` and the disk-mode subprocess runner for a MAP→MAPREDUCE pipeline.
  - `test_in_memory_rejects_incompatible_flags` / `test_in_memory_rejects_stage_runner_fp` — incompatible-flag combinations raise `ValueError`.
- [x] Doctests on `compute_modes/in_memory.py`, `mapreduce/reducer.py`, `mapreduce/rwlock.py`, `runner.py` — all passing.
- [x] Full test suite: 76 passed, 2 pre-existing parallel-only failures (unrelated — fail on the base branch too).

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)