### PR TITLE
Hoist Path-spec StageExample infrastructure (issue #387, Option B)

### DIFF
--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import subprocess
 import tempfile
 import textwrap
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import Any, ClassVar
 
 import polars as pl
 from meds import DatasetMetadataSchema, code_metadata_filepath
@@ -22,9 +23,6 @@ from omegaconf import DictConfig, OmegaConf
 from polars.testing import assert_frame_equal
 from pretty_print_directory import list_directory
 from yaml import load as load_yaml
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 _SPACE = "    "
 _BRANCH = "│   "
@@ -275,6 +273,54 @@ class TestEnv:
             lines.extend(textwrap.indent(cfg_yaml_contents, _SPACE + _BRANCH).splitlines())
         lines.append(f"  - Script: {self.script}")
         return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class CompareContext:
+    """Context bundle passed to per-suffix output comparators.
+
+    Kept minimal on purpose: comparators that need new tolerance knobs (e.g. NRT atol/rtol) pull
+    them from ``tolerances`` under their own suffix key, so the comparator signature never has
+    to grow.
+
+    Attributes:
+        rel: The expected file's path relative to the expected root. Used in error messages so
+            the failure points at the logical location a stage author cares about.
+        tolerances: Per-suffix tolerance bundles. A comparator looks up ``tolerances.get(".parquet")``,
+            ``tolerances.get(".nrt")``, etc. Empty dict if the caller didn't configure any.
+    """
+
+    rel: Path
+    tolerances: Mapping[str, Any] = field(default_factory=dict)
+
+    def tol_for(self, suffix: str) -> dict:
+        """Return a (possibly empty) tolerance dict for ``suffix``.
+
+        Always a fresh dict.
+        """
+        return dict(self.tolerances.get(suffix, {}))
+
+
+#: Comparator signature. Must ``raise AssertionError`` on mismatch; return value is ignored.
+ComparatorFn = Callable[[Path, Path, "CompareContext"], None]
+
+
+def _compare_parquet(expected_fp: Path, actual_fp: Path, ctx: CompareContext) -> None:
+    """Default comparator for ``.parquet`` outputs.
+
+    Uses ``pl.read_parquet(..., glob=False)`` on both sides (raw shard filenames like
+    ``[0-10).parquet`` that appear in extraction pipelines carry glob metacharacters). Tolerance
+    comes from ``ctx.tol_for('.parquet')`` and is forwarded to ``polars.testing.assert_frame_equal``.
+    """
+    try:
+        want = pl.read_parquet(expected_fp, glob=False)
+        got = pl.read_parquet(actual_fp, glob=False)
+    except Exception as e:
+        raise AssertionError(f"Failed to read parquet at {ctx.rel}: {e}") from e
+    try:
+        assert_frame_equal(want, got, **ctx.tol_for(".parquet"))
+    except AssertionError as e:
+        raise AssertionError(f"Parquet mismatch at {ctx.rel}:\n  want:\n{want}\n  got:\n{got}") from e
 
 
 @dataclass
@@ -848,19 +894,44 @@ class StageExample:
     stage_name: str
     scenario_name: str | None = None
     stage_cfg: dict = field(default_factory=dict)
-    want_data: MEDSDataset | None = None
-    want_metadata: pl.DataFrame | None = None
+    want_data: MEDSDataset | Path | None = None
+    want_metadata: pl.DataFrame | Path | None = None
     in_data: MEDSDataset | Path | None = None
     pipeline_cfg: dict = field(default_factory=dict)
     do_use_config_yaml: bool = False
     df_check_kwargs: dict | None = None
+    #: Top-level directory names to ignore when comparing a Path-spec output tree against the
+    #: actual output directory. Defaults cover the usual Hydra / logging byproducts.
+    skip_dirs: frozenset[str] = field(default_factory=lambda: frozenset({".logs", ".hydra"}))
+    #: File names (matched anywhere in the actual output) to ignore when reconciling expected
+    #: vs. actual. Empty by default; subclasses set this to ignore stage-specific auxiliary files.
+    skip_files: frozenset[str] = field(default_factory=frozenset)
+    #: If ``True``, actual-output files that the Path spec does not mention are silently ignored
+    #: rather than raising. Defaults to strict behavior.
+    tolerate_unexpected: bool = False
+    #: Per-instance override of the per-suffix comparator map. ``None`` means "use the
+    #: subclass's ``SUFFIX_COMPARATORS`` class var (merged with base defaults)".
+    suffix_comparators: dict[str, ComparatorFn] | None = None
 
     BASE_PACKAGE: ClassVar[str] = "__null__"
+    #: Default per-suffix comparators, resolved at the class level. Downstream packages subclass
+    #: ``StageExample`` and override this to register format-specific comparators (MTD's ``.nrt``,
+    #: MEDS-extract's ``.json``/``.yaml``). Per-instance overrides via ``suffix_comparators``
+    #: take precedence over this.
+    SUFFIX_COMPARATORS: ClassVar[dict[str, ComparatorFn]] = {".parquet": _compare_parquet}
 
     def __post_init__(self):
         if self.want_data is None and self.want_metadata is None:
             raise ValueError("Either want_data or want_metadata must be provided.")
-        elif self.want_data is not None and self.want_metadata is not None:
+        elif (
+            self.want_data is not None
+            and self.want_metadata is not None
+            and not isinstance(self.want_data, Path)
+            and not isinstance(self.want_metadata, Path)
+        ):
+            # The XOR rule is about MEDSDataset + DataFrame ambiguity; Path-spec examples may
+            # legitimately describe both data and metadata file trees simultaneously (e.g.
+            # extraction stages emit raw shard parquets AND a metadata/codes.parquet in one run).
             raise ValueError("Either want_data or want_metadata must be provided, but not both.")
 
         if self.scenario_name == ".":
@@ -871,6 +942,12 @@ class StageExample:
 
         if self.df_check_kwargs is None:
             self.df_check_kwargs = {"rel_tol": 1e-3, "abs_tol": 1e-5}
+
+    def _resolve_comparators(self) -> dict[str, ComparatorFn]:
+        """Return the effective comparator map: instance override wins over class default."""
+        return dict(
+            self.suffix_comparators if self.suffix_comparators is not None else self.SUFFIX_COMPARATORS
+        )
 
     @classmethod
     def is_example_dir(cls, path: Path) -> bool:
@@ -904,9 +981,18 @@ class StageExample:
         want_data = None
         want_metadata = None
         if want_data_fp.is_file():
-            want_data = MEDSDataset.from_yaml(want_data_fp, **schema_updates)
+            try:
+                want_data = MEDSDataset.from_yaml(want_data_fp, **schema_updates)
+            except (ValueError, TypeError):
+                # Not a MEDS-format spec — fall back to a Path to the yaml_to_disk file, to be
+                # materialized and compared file-by-file via SUFFIX_COMPARATORS. Mirrors the
+                # graceful fallback already used for ``in_data`` below.
+                want_data = want_data_fp
         if want_metadata_fp.is_file():
-            want_metadata = read_metadata_only(want_metadata_fp, **schema_updates)
+            try:
+                want_metadata = read_metadata_only(want_metadata_fp, **schema_updates)
+            except (ValueError, TypeError):
+                want_metadata = want_metadata_fp
 
         in_data = None
         if in_fp.is_file():
@@ -989,7 +1075,11 @@ class StageExample:
 
         all_files_str = f"{output_dir.name}\n" + "\n".join(list_directory(output_dir))
 
-        if self.want_data is not None:
+        # ``__check_files`` enforces the MEDSDataset / DataFrame layout assumption (``data/`` +
+        # ``metadata/codes.parquet``). Path-spec fields describe their own layout via
+        # ``yaml_to_disk``, so we skip this prefix check in that case — the file-by-file walk in
+        # ``_check_path_spec`` gives a better failure mode.
+        if isinstance(self.want_data, MEDSDataset):
             data_dir = output_dir if is_resolved_dir else output_dir / "data"
             if not self.__data_files(data_dir):
                 raise AssertionError(
@@ -997,7 +1087,7 @@ class StageExample:
                     f"{all_files_str}"
                 )
 
-        if self.want_metadata is not None:
+        if isinstance(self.want_metadata, pl.DataFrame):
             metadata_dir = output_dir if is_resolved_dir else output_dir / "metadata"
             metadata_fp = metadata_dir / "codes.parquet"
             if not metadata_fp.is_file():
@@ -1005,10 +1095,81 @@ class StageExample:
                     f"Expected metadata file {code_metadata_filepath} in {output_dir}. Got:\n{all_files_str}"
                 )
 
+    def _check_path_spec(self, spec_fp: Path, output_dir: Path) -> None:
+        """Compare an actual output tree against a ``yaml_to_disk`` spec file-by-file.
+
+        Expected files are materialized into a tempdir via ``yaml_to_disk.yaml_disk``, then each
+        file is compared against its counterpart under ``output_dir`` using the per-suffix
+        comparator resolved from :meth:`_resolve_comparators`. The comparator-to-context bridge
+        puts ``self.df_check_kwargs`` under ``tolerances['.parquet']`` so the default parquet
+        comparator picks it up.
+
+        Args:
+            spec_fp: Path to the ``yaml_to_disk`` spec describing the expected output tree.
+            output_dir: Root of the actual output tree to compare against.
+
+        Raises:
+            AssertionError: If an expected file is missing, a comparator reports a mismatch, or
+                (when ``tolerate_unexpected=False``) the actual tree has files the spec doesn't
+                mention (after applying ``skip_dirs`` / ``skip_files``).
+            RuntimeError: If a file's suffix has no registered comparator.
+        """
+        from yaml_to_disk import yaml_disk
+
+        comparators = self._resolve_comparators()
+        tolerances = {".parquet": dict(self.df_check_kwargs or {})}
+
+        with tempfile.TemporaryDirectory() as expected_root:
+            expected_root = Path(expected_root)
+            yaml_disk(spec_fp, root_dir=expected_root)
+
+            expected_rel: set[Path] = set()
+            for expected_fp in sorted(expected_root.rglob("*")):
+                if not expected_fp.is_file():
+                    continue
+                rel = expected_fp.relative_to(expected_root)
+                expected_rel.add(rel)
+                actual_fp = output_dir / rel
+                if not actual_fp.is_file():
+                    raise AssertionError(f"Expected output file {rel} not found under {output_dir}")
+                comparator = comparators.get(expected_fp.suffix)
+                if comparator is None:
+                    raise RuntimeError(
+                        f"No comparator registered for {expected_fp.suffix!r} "
+                        f"(file {rel}). Register one on SUFFIX_COMPARATORS or "
+                        f"pass suffix_comparators= to the StageExample."
+                    )
+                comparator(expected_fp, actual_fp, CompareContext(rel=rel, tolerances=tolerances))
+
+            if not self.tolerate_unexpected:
+                actual_rel = self.__actual_files_rel(output_dir)
+                extra = actual_rel - expected_rel
+                if extra:
+                    raise AssertionError(
+                        f"Unexpected files in {output_dir} (not in {spec_fp.name}): "
+                        f"{sorted(str(p) for p in extra)}"
+                    )
+
+    def __actual_files_rel(self, output_dir: Path) -> set[Path]:
+        """Return file paths under ``output_dir`` (relative), after applying skip_dirs/skip_files."""
+        out: set[Path] = set()
+        for fp in output_dir.rglob("*"):
+            if not fp.is_file():
+                continue
+            rel = fp.relative_to(output_dir)
+            if rel.parts and rel.parts[0] in self.skip_dirs:
+                continue
+            if fp.name in self.skip_files:
+                continue
+            out.add(rel)
+        return out
+
     def check_outputs(self, output_dir: Path, is_resolved_dir: bool = False) -> None:
         self.__check_files(output_dir, is_resolved_dir)
 
-        if self.want_data is not None:
+        if isinstance(self.want_data, Path):
+            self._check_path_spec(self.want_data, output_dir)
+        elif isinstance(self.want_data, MEDSDataset):
             data_dir = output_dir if is_resolved_dir else output_dir / "data"
             got_data = MEDSDataset(
                 data_shards=self.__data_shards(data_dir), dataset_metadata=DatasetMetadataSchema()
@@ -1028,7 +1189,9 @@ class StageExample:
                 pl.Config.set_tbl_rows(-1)
                 raise AssertionError(f"Want data:\n{self.want_data}\nGot data:\n{got_data}") from e
 
-        if self.want_metadata is not None:
+        if isinstance(self.want_metadata, Path):
+            self._check_path_spec(self.want_metadata, output_dir)
+        elif isinstance(self.want_metadata, pl.DataFrame):
             metadata_dir = output_dir if is_resolved_dir else output_dir / "metadata"
             metadata_fp = metadata_dir / "codes.parquet"
             got_metadata = pl.read_parquet(metadata_fp)

--- a/src/MEDS_transforms/stages/examples.py
+++ b/src/MEDS_transforms/stages/examples.py
@@ -983,15 +983,19 @@ class StageExample:
         if want_data_fp.is_file():
             try:
                 want_data = MEDSDataset.from_yaml(want_data_fp, **schema_updates)
-            except (ValueError, TypeError):
+            except ValueError:
                 # Not a MEDS-format spec — fall back to a Path to the yaml_to_disk file, to be
                 # materialized and compared file-by-file via SUFFIX_COMPARATORS. Mirrors the
-                # graceful fallback already used for ``in_data`` below.
+                # graceful fallback already used for ``in_data`` below. ``TypeError`` is
+                # deliberately *not* caught: a YAML that parses to the wrong types (e.g. a list
+                # where a dict is expected) is a user error, not a "treat as opaque file spec"
+                # case, and should surface during loading rather than re-emerge as a confusing
+                # path-spec mismatch in ``check_outputs``.
                 want_data = want_data_fp
         if want_metadata_fp.is_file():
             try:
                 want_metadata = read_metadata_only(want_metadata_fp, **schema_updates)
-            except (ValueError, TypeError):
+            except ValueError:
                 want_metadata = want_metadata_fp
 
         in_data = None
@@ -1095,8 +1099,8 @@ class StageExample:
                     f"Expected metadata file {code_metadata_filepath} in {output_dir}. Got:\n{all_files_str}"
                 )
 
-    def _check_path_spec(self, spec_fp: Path, output_dir: Path) -> None:
-        """Compare an actual output tree against a ``yaml_to_disk`` spec file-by-file.
+    def _compare_path_spec(self, spec_fp: Path, output_dir: Path) -> set[Path]:
+        """Compare an actual output tree against one ``yaml_to_disk`` spec, file-by-file.
 
         Expected files are materialized into a tempdir via ``yaml_to_disk.yaml_disk``, then each
         file is compared against its counterpart under ``output_dir`` using the per-suffix
@@ -1104,14 +1108,18 @@ class StageExample:
         puts ``self.df_check_kwargs`` under ``tolerances['.parquet']`` so the default parquet
         comparator picks it up.
 
+        Returns the set of expected file rel-paths covered by this spec so the caller can union
+        across multiple specs before doing the no-unexpected-files check. The caller owns that
+        check: when ``want_data`` and ``want_metadata`` are *both* Paths, neither spec alone
+        knows about the other's files, so each one must contribute its expected set and the
+        check happens against the union.
+
         Args:
             spec_fp: Path to the ``yaml_to_disk`` spec describing the expected output tree.
             output_dir: Root of the actual output tree to compare against.
 
         Raises:
-            AssertionError: If an expected file is missing, a comparator reports a mismatch, or
-                (when ``tolerate_unexpected=False``) the actual tree has files the spec doesn't
-                mention (after applying ``skip_dirs`` / ``skip_files``).
+            AssertionError: If an expected file is missing, or a comparator reports a mismatch.
             RuntimeError: If a file's suffix has no registered comparator.
         """
         from yaml_to_disk import yaml_disk
@@ -1141,14 +1149,24 @@ class StageExample:
                     )
                 comparator(expected_fp, actual_fp, CompareContext(rel=rel, tolerances=tolerances))
 
-            if not self.tolerate_unexpected:
-                actual_rel = self.__actual_files_rel(output_dir)
-                extra = actual_rel - expected_rel
-                if extra:
-                    raise AssertionError(
-                        f"Unexpected files in {output_dir} (not in {spec_fp.name}): "
-                        f"{sorted(str(p) for p in extra)}"
-                    )
+        return expected_rel
+
+    def _check_path_spec(self, spec_fp: Path, output_dir: Path) -> None:
+        """Single-spec wrapper around :meth:`_compare_path_spec` with no-unexpected-files check.
+
+        Used when only one of ``want_data`` / ``want_metadata`` is a Path. When both are Paths,
+        ``check_outputs`` calls ``_compare_path_spec`` directly and runs a single union-aware
+        unexpected-files check across both specs.
+        """
+        expected_rel = self._compare_path_spec(spec_fp, output_dir)
+        if not self.tolerate_unexpected:
+            actual_rel = self.__actual_files_rel(output_dir)
+            extra = actual_rel - expected_rel
+            if extra:
+                raise AssertionError(
+                    f"Unexpected files in {output_dir} (not in {spec_fp.name}): "
+                    f"{sorted(str(p) for p in extra)}"
+                )
 
     def __actual_files_rel(self, output_dir: Path) -> set[Path]:
         """Return file paths under ``output_dir`` (relative), after applying skip_dirs/skip_files."""
@@ -1166,6 +1184,22 @@ class StageExample:
 
     def check_outputs(self, output_dir: Path, is_resolved_dir: bool = False) -> None:
         self.__check_files(output_dir, is_resolved_dir)
+
+        # Both fields as Paths: union the expected sets so the no-unexpected-files check
+        # doesn't reject one spec's files for being absent from the other's. This is the
+        # extraction-style use case the XOR relaxation enables.
+        if isinstance(self.want_data, Path) and isinstance(self.want_metadata, Path):
+            expected = self._compare_path_spec(self.want_data, output_dir)
+            expected |= self._compare_path_spec(self.want_metadata, output_dir)
+            if not self.tolerate_unexpected:
+                actual_rel = self.__actual_files_rel(output_dir)
+                extra = actual_rel - expected
+                if extra:
+                    raise AssertionError(
+                        f"Unexpected files in {output_dir} (not in either spec): "
+                        f"{sorted(str(p) for p in extra)}"
+                    )
+            return
 
         if isinstance(self.want_data, Path):
             self._check_path_spec(self.want_data, output_dir)

--- a/tests/test_filespec_stageexample.py
+++ b/tests/test_filespec_stageexample.py
@@ -131,8 +131,11 @@ def test_check_outputs_path_spec_mismatch_propagates_comparator_error(tmp_path: 
         want_data=spec,
         suffix_comparators={".csv": _strict_text_compare},
     )
-    with pytest.raises(AssertionError, match="CSV mismatch"):
+    with pytest.raises(AssertionError, match="CSV mismatch") as excinfo:
         ex.check_outputs(actual, is_resolved_dir=True)
+    # The comparator received ``ctx.rel`` and used it; without that thread, users wouldn't
+    # know which file failed when many files are checked in one ``check_outputs`` call.
+    assert "data/a.csv" in str(excinfo.value)
 
 
 def test_check_outputs_path_spec_missing_file_raises(tmp_path: Path):
@@ -228,6 +231,62 @@ def test_custom_skip_files_ignores_named_file(tmp_path: Path):
         skip_files=frozenset({"README"}),
     )
     ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_skip_files_matches_basename_in_nested_dirs(tmp_path: Path):
+    """``skip_files`` filters by basename so a file at any depth is ignored.
+
+    The implementation uses ``fp.name``; this test pins that behavior so a future change to
+    full-path matching (which would silently break user configs) requires intentional update.
+    """
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data" / "sub").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    (actual / "data" / "sub" / "README").write_text("nested notes\n")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+        skip_files=frozenset({"README"}),
+    )
+    ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_check_outputs_runs_path_spec_for_both_want_data_and_want_metadata(tmp_path: Path):
+    """When both ``want_data`` and ``want_metadata`` are Paths, ``check_outputs`` runs both.
+
+    Locks in the XOR-relaxation: extraction-style stages legitimately describe a data file tree
+    AND a metadata file tree side-by-side. If the dispatch ever regressed to checking only one
+    side, the test would catch it because each spec asserts a different file's presence.
+    """
+    data_spec = _write_yaml_spec(tmp_path / "want_data.yaml", "data/a.csv: |\n  x\n  1\n")
+    metadata_spec = _write_yaml_spec(tmp_path / "want_metadata.yaml", "metadata/manifest.csv: |\n  v\n  42\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "metadata").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    (actual / "metadata" / "manifest.csv").write_text("v\n42\n")
+
+    def _csv_eq(exp_fp: Path, act_fp: Path, ctx: CompareContext) -> None:
+        # Strip trailing whitespace because yaml_to_disk materialization may not preserve a
+        # final newline — the comparison is content-equality, not byte-equality.
+        assert exp_fp.read_text().strip() == act_fp.read_text().strip(), f"mismatch at {ctx.rel}"
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=data_spec,
+        want_metadata=metadata_spec,
+        suffix_comparators={".csv": _csv_eq},
+    )
+    # Must not raise — both spec branches ran successfully.
+    ex.check_outputs(actual, is_resolved_dir=True)
+
+    # And if either side is wrong, the comparator fires with the right rel path.
+    (actual / "metadata" / "manifest.csv").write_text("v\n999\n")
+    with pytest.raises(AssertionError, match=r"metadata/manifest\.csv"):
+        ex.check_outputs(actual, is_resolved_dir=True)
 
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/test_filespec_stageexample.py
+++ b/tests/test_filespec_stageexample.py
@@ -1,0 +1,346 @@
+"""End-to-end tests for Path-spec StageExample (issue #387, Option B)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import polars as pl
+import pytest
+
+from MEDS_transforms.stages.examples import (
+    ComparatorFn,
+    CompareContext,
+    StageExample,
+    _compare_parquet,
+)
+
+
+@pytest.fixture
+def simple_parquet(tmp_path: Path) -> Path:
+    """A tiny parquet file at a stable path for reuse."""
+    fp = tmp_path / "data.parquet"
+    pl.DataFrame({"a": [1, 2]}).write_parquet(fp)
+    return fp
+
+
+def _write_yaml_spec(fp: Path, contents: str) -> Path:
+    fp.write_text(contents)
+    return fp
+
+
+# ---------------------------------------------------------------------------------------------
+# Path-as-want_data / want_metadata
+# ---------------------------------------------------------------------------------------------
+
+
+def test_both_want_fields_as_paths_permitted(tmp_path: Path):
+    """XOR rule only applies to MEDSDataset + DataFrame pair; Path specs may describe both."""
+    spec1 = _write_yaml_spec(tmp_path / "out_data.yaml", "data/x.parquet: |\n  a,b\n  1,2\n")
+    spec2 = _write_yaml_spec(tmp_path / "out_metadata.yaml", "metadata/codes.parquet: |\n  code\n  foo\n")
+
+    # Should not raise.
+    ex = StageExample(stage_name="test", want_data=spec1, want_metadata=spec2)
+    assert ex.want_data == spec1
+    assert ex.want_metadata == spec2
+
+
+def test_xor_rule_still_applies_for_medsdataset_and_dataframe(tmp_path: Path):
+    """Two non-Path types simultaneously is still a misuse."""
+    from meds_testing_helpers.dataset import MEDSDataset
+    from meds_testing_helpers.static_sample_data import SIMPLE_STATIC_SHARDED_BY_SPLIT
+
+    ds = MEDSDataset.from_yaml(SIMPLE_STATIC_SHARDED_BY_SPLIT)
+    md = pl.DataFrame({"code": ["x"]})
+
+    with pytest.raises(ValueError, match="but not both"):
+        StageExample(stage_name="test", want_data=ds, want_metadata=md)
+
+
+def test_from_dir_falls_back_to_path_for_non_meds_output(tmp_path: Path):
+    """out_data.yaml that isn't a MEDS spec is stored as Path (mirrors in_data behavior)."""
+    import yaml
+
+    example_dir = tmp_path / "example"
+    example_dir.mkdir()
+    # A yaml_to_disk spec that isn't MEDS-shaped.
+    (example_dir / "out_data.yaml").write_text(
+        yaml.dump({"raw/chunk.parquet": None, "sidecar/manifest.json": {"v": 1}})
+    )
+    (example_dir / "cfg.yaml").write_text(yaml.dump({}))
+
+    ex = StageExample.from_dir("test", ".", example_dir)
+    assert isinstance(ex.want_data, Path)
+    assert ex.want_data == example_dir / "out_data.yaml"
+
+
+def test_from_dir_still_parses_valid_meds_output(tmp_path: Path):
+    """A MEDS-shaped out_data.yaml is still parsed as a MEDSDataset (no regression)."""
+    from meds_testing_helpers.dataset import MEDSDataset
+
+    example_dir = tmp_path / "example"
+    example_dir.mkdir()
+    (example_dir / "out_data.yaml").write_text(
+        "data/train/0: |-2\n"
+        "  subject_id,time,code,numeric_value\n"
+        "  1,,GENDER//M,\n"
+        "metadata/codes.parquet: |-2\n"
+        "  code,description,parent_codes\n"
+        "  GENDER//M,,\n"
+    )
+    (example_dir / "cfg.yaml").write_text("")
+
+    ex = StageExample.from_dir("test", ".", example_dir)
+    assert isinstance(ex.want_data, MEDSDataset)
+
+
+# ---------------------------------------------------------------------------------------------
+# check_outputs dispatching through the comparator map
+# ---------------------------------------------------------------------------------------------
+
+
+def test_check_outputs_path_spec_passes_when_parquet_matches(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "out_data.yaml", "data/shard.csv: |\n  a\n  1\n  2\n")
+    # Create an "actual" output that matches the spec byte-for-byte using yaml_disk directly.
+    from yaml_to_disk import yaml_disk
+
+    actual = tmp_path / "actual"
+    actual.mkdir()
+    yaml_disk(spec, root_dir=actual)
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},  # accept anything
+    )
+    ex.check_outputs(actual, is_resolved_dir=True)  # must not raise
+
+
+def test_check_outputs_path_spec_mismatch_propagates_comparator_error(tmp_path: Path):
+    """A comparator-raised AssertionError surfaces cleanly from check_outputs."""
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n9\n")
+
+    def _strict_text_compare(exp_fp: Path, act_fp: Path, ctx: CompareContext) -> None:
+        assert exp_fp.read_text() == act_fp.read_text(), f"CSV mismatch at {ctx.rel}"
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": _strict_text_compare},
+    )
+    with pytest.raises(AssertionError, match="CSV mismatch"):
+        ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_check_outputs_path_spec_missing_file_raises(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/shard.csv: |\n  a\n  1\n")
+    actual = tmp_path / "actual"
+    actual.mkdir()
+
+    ex = StageExample(stage_name="test", want_data=spec)
+    with pytest.raises(AssertionError, match="not found"):
+        ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_unknown_suffix_raises_runtime_error(tmp_path: Path):
+    """No comparator for the suffix → explicit RuntimeError pointing at registration."""
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/x.weird: foo\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "x.weird").write_text("foo\n")
+
+    ex = StageExample(stage_name="test", want_data=spec)
+    with pytest.raises(RuntimeError, match=r"No comparator registered for '\.weird'"):
+        ex.check_outputs(actual, is_resolved_dir=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# Policy fields: skip lists, tolerate_unexpected
+# ---------------------------------------------------------------------------------------------
+
+
+def test_tolerate_unexpected_false_flags_extra_files(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    (actual / "data" / "leftover.csv").write_text("y\n9\n")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+    )
+    with pytest.raises(AssertionError, match="Unexpected files"):
+        ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_tolerate_unexpected_true_ignores_extra_files(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    (actual / "data" / "leftover.csv").write_text("y\n9\n")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+        tolerate_unexpected=True,
+    )
+    ex.check_outputs(actual, is_resolved_dir=True)  # must not raise
+
+
+def test_default_skip_dirs_ignores_hydra_and_logs(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    # Simulate Hydra-emitted noise alongside the real outputs.
+    (actual / ".logs").mkdir()
+    (actual / ".logs" / "run.log").write_text("...\n")
+    (actual / ".hydra").mkdir()
+    (actual / ".hydra" / "config.yaml").write_text("x: 1\n")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+    )
+    # .logs and .hydra must be silently ignored even under strict tolerate_unexpected=False.
+    ex.check_outputs(actual, is_resolved_dir=True)
+
+
+def test_custom_skip_files_ignores_named_file(tmp_path: Path):
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "data/a.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    (actual / "data").mkdir(parents=True)
+    (actual / "data" / "a.csv").write_text("x\n1\n")
+    (actual / "data" / "README").write_text("stage notes\n")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+        skip_files=frozenset({"README"}),
+    )
+    ex.check_outputs(actual, is_resolved_dir=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# Comparator registry: class default + per-instance override
+# ---------------------------------------------------------------------------------------------
+
+
+def test_class_level_comparator_registration(tmp_path: Path):
+    """Subclasses register format-specific comparators via SUFFIX_COMPARATORS."""
+    calls = {"json": 0}
+
+    def _compare_json_contents(exp_fp, act_fp, ctx: CompareContext) -> None:
+        calls["json"] += 1
+        # Strip trailing whitespace so we don't trip over yaml_to_disk materialization nuances.
+        assert exp_fp.read_text().strip() == act_fp.read_text().strip(), f"JSON mismatch at {ctx.rel}"
+
+    class JSONAwareExample(StageExample):
+        SUFFIX_COMPARATORS: ClassVar[dict] = {
+            **StageExample.SUFFIX_COMPARATORS,
+            ".json": _compare_json_contents,
+        }
+
+    # Use yaml_to_disk and a byte-equal actual copy so we don't have to guess at yaml_to_disk's
+    # quoting/escaping behavior for JSON literal contents.
+    from yaml_to_disk import yaml_disk
+
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "extra/m.json: |\n  manifest line\n")
+    actual = tmp_path / "actual"
+    actual.mkdir()
+    yaml_disk(spec, root_dir=actual)
+
+    ex = JSONAwareExample(stage_name="test", want_data=spec)
+    ex.check_outputs(actual, is_resolved_dir=True)
+    assert calls["json"] == 1
+
+
+def test_per_instance_comparator_overrides_class_default(tmp_path: Path):
+    """Instance-level suffix_comparators wins over the class-level SUFFIX_COMPARATORS."""
+    spec = _write_yaml_spec(tmp_path / "want.yaml", "x.parquet: 0\n")
+    actual = tmp_path / "actual"
+    actual.mkdir()
+    pl.DataFrame({"a": [1, 2]}).write_parquet(actual / "x.parquet")
+
+    # Custom comparator that always says "mismatch" — proves the class-level .parquet default
+    # was NOT used.
+    def _always_fail(exp_fp, act_fp, ctx):
+        raise AssertionError(f"custom comparator: {ctx.rel}")
+
+    ex = StageExample(
+        stage_name="test",
+        want_data=spec,
+        suffix_comparators={".parquet": _always_fail},
+    )
+    with pytest.raises(AssertionError, match="custom comparator"):
+        ex.check_outputs(actual, is_resolved_dir=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# Default parquet comparator behavior
+# ---------------------------------------------------------------------------------------------
+
+
+def test_compare_parquet_tolerance_bridge(tmp_path: Path):
+    """df_check_kwargs flows through CompareContext.tol_for('.parquet')."""
+    # Values differ by more than default atol but within loose rtol — strict would fail, loose passes.
+    pl.DataFrame({"a": [1.0]}).write_parquet(tmp_path / "want.parquet")
+    pl.DataFrame({"a": [1.001]}).write_parquet(tmp_path / "got.parquet")
+
+    strict_ctx = CompareContext(rel=Path("a"), tolerances={".parquet": {"rel_tol": 0.0, "abs_tol": 0.0}})
+    with pytest.raises(AssertionError, match="Parquet mismatch"):
+        _compare_parquet(tmp_path / "want.parquet", tmp_path / "got.parquet", strict_ctx)
+
+    loose_ctx = CompareContext(rel=Path("a"), tolerances={".parquet": {"rel_tol": 1e-2, "abs_tol": 1e-2}})
+    _compare_parquet(tmp_path / "want.parquet", tmp_path / "got.parquet", loose_ctx)  # no raise
+
+
+def test_medsdataset_branch_unchanged(tmp_path: Path):
+    """Legacy MEDSDataset check_outputs path still works exactly as before."""
+    from meds_testing_helpers.dataset import MEDSDataset
+    from meds_testing_helpers.static_sample_data import SIMPLE_STATIC_SHARDED_BY_SPLIT
+
+    ds = MEDSDataset.from_yaml(SIMPLE_STATIC_SHARDED_BY_SPLIT)
+    ex = StageExample(stage_name="test", want_data=ds)
+
+    output_dir = tmp_path / "cohort"
+    (output_dir / "data").mkdir(parents=True)
+    ds.write(output_dir)
+
+    ex.check_outputs(output_dir)  # must not raise
+
+
+# ---------------------------------------------------------------------------------------------
+# _resolve_comparators behavior
+# ---------------------------------------------------------------------------------------------
+
+
+def test_resolve_comparators_class_default(tmp_path: Path):
+    ex = StageExample(stage_name="test", want_metadata=pl.DataFrame({"code": ["x"]}))
+    resolved = ex._resolve_comparators()
+    assert ".parquet" in resolved
+    assert resolved[".parquet"] is _compare_parquet
+
+
+def test_resolve_comparators_instance_override(tmp_path: Path):
+    def my_parquet(*args, **kwargs):
+        pass
+
+    fake: ComparatorFn = my_parquet
+    ex = StageExample(
+        stage_name="test",
+        want_metadata=pl.DataFrame({"code": ["x"]}),
+        suffix_comparators={".parquet": fake, ".foo": fake},
+    )
+    resolved = ex._resolve_comparators()
+    assert resolved[".parquet"] is fake
+    assert resolved[".foo"] is fake

--- a/tests/test_filespec_stageexample.py
+++ b/tests/test_filespec_stageexample.py
@@ -290,6 +290,47 @@ def test_per_instance_comparator_overrides_class_default(tmp_path: Path):
 # ---------------------------------------------------------------------------------------------
 
 
+def test_compare_parquet_read_failure_raises_assertion(tmp_path: Path):
+    """Corrupt / unreadable parquet surfaces as AssertionError, not a raw polars exception."""
+    (tmp_path / "want.parquet").write_bytes(b"not a parquet file")
+    pl.DataFrame({"a": [1]}).write_parquet(tmp_path / "got.parquet")
+    ctx = CompareContext(rel=Path("want.parquet"), tolerances={".parquet": {}})
+    with pytest.raises(AssertionError, match=r"Failed to read parquet at want\.parquet"):
+        _compare_parquet(tmp_path / "want.parquet", tmp_path / "got.parquet", ctx)
+
+
+def test_from_dir_falls_back_to_path_for_non_meds_metadata(tmp_path: Path):
+    """out_metadata.yaml that isn't a MEDS-shaped metadata spec is stored as Path."""
+    import yaml
+
+    example_dir = tmp_path / "example"
+    example_dir.mkdir()
+    # A yaml_to_disk spec that isn't in metadata/codes.parquet shape.
+    (example_dir / "out_metadata.yaml").write_text(yaml.dump({"extra/manifest.json": {"v": 1}}))
+    (example_dir / "cfg.yaml").write_text(yaml.dump({}))
+
+    ex = StageExample.from_dir("test", ".", example_dir)
+    assert isinstance(ex.want_metadata, Path)
+    assert ex.want_metadata == example_dir / "out_metadata.yaml"
+
+
+def test_check_outputs_dispatches_path_spec_on_want_metadata(tmp_path: Path):
+    """want_metadata as Path goes through _check_path_spec just like want_data."""
+    from yaml_to_disk import yaml_disk
+
+    spec = _write_yaml_spec(tmp_path / "out_metadata.yaml", "extra/m.csv: |\n  x\n  1\n")
+    actual = tmp_path / "actual"
+    actual.mkdir()
+    yaml_disk(spec, root_dir=actual)
+
+    ex = StageExample(
+        stage_name="test",
+        want_metadata=spec,
+        suffix_comparators={".csv": lambda a, b, ctx: None},
+    )
+    ex.check_outputs(actual, is_resolved_dir=True)  # must not raise
+
+
 def test_compare_parquet_tolerance_bridge(tmp_path: Path):
     """df_check_kwargs flows through CompareContext.tol_for('.parquet')."""
     # Values differ by more than default atol but within loose rtol — strict would fail, loose passes.


### PR DESCRIPTION
## Summary

Closes #387 (Option B). The upstream `StageExample` assumed outputs were either a `MEDSDataset` under `data/*.parquet` or a single `metadata/codes.parquet` — so two derived packages (meds-torch-data and MEDS-extract) independently reinvented the same ~200-LOC subclass: Path-based `want_data` / `want_metadata` plus a per-suffix comparator dispatcher.

This PR hoists that scaffolding into the base class so derived packages collapse to ~20 LOC.

## Depends on

**#389** — the `render_content` / `want_metadata: Path` bug-fix prerequisite. That PR is deliberately minimal (rendering dispatch only); this one adds the type widening + check_outputs dispatch + comparator registry on top.

## Changes

### Type widening
- `want_data: MEDSDataset | Path | None`
- `want_metadata: pl.DataFrame | Path | None`

A `Path` is interpreted as a `yaml_to_disk` spec describing the expected output tree.

### `from_dir` graceful fallback
- Try `MEDSDataset.from_yaml(out_data_fp)` / `read_metadata_only(out_metadata_fp)` first. On `ValueError` / `TypeError`, store the `Path` itself and let `check_outputs` dispatch to the file-spec path later. Mirrors the existing `in_data` pattern exactly.

### New `check_outputs` dispatch
- `MEDSDataset` / `pl.DataFrame` branches are byte-identical to before (no regression for existing stages).
- `Path` branches go through the new `_check_path_spec`, which:
  1. materializes the spec into a tempdir via `yaml_to_disk.yaml_disk`;
  2. walks the expected tree, compares each file to its counterpart under the actual output dir via a per-suffix `ComparatorFn`;
  3. asserts the actual tree has no unexpected files (unless `tolerate_unexpected=True`), after filtering out `skip_dirs` / `skip_files`.

### Policy fields (dataclass fields, not ClassVars)
- `skip_dirs: frozenset[str]` — defaults to `{.logs, .hydra}` (the usual Hydra / logging byproducts both downstream packages reinvented).
- `skip_files: frozenset[str]` — empty default.
- `tolerate_unexpected: bool` — defaults to strict.
- `suffix_comparators: dict[str, ComparatorFn] | None` — per-instance override of the class default.

### Comparator registry (no process-global state)
- Class-level default: `SUFFIX_COMPARATORS: ClassVar[dict[str, ComparatorFn]] = {".parquet": _compare_parquet}`.
- Subclasses register additional comparators via standard class-var override (`class MTDStageExample(StageExample): SUFFIX_COMPARATORS = {..., ".nrt": _compare_nrt}`).
- Per-instance `suffix_comparators` overrides the class default for one-offs (e.g. relaxed tolerance on a specific example).
- No `@register_comparator` decorator — explicitly avoided per the design-discussion comment.

### Comparator signature
```python
ComparatorFn = Callable[[Path, Path, CompareContext], None]
```
`CompareContext` is a frozen dataclass carrying `rel: Path` (for error messages) and `tolerances: Mapping[str, Any]` keyed by suffix. `df_check_kwargs` is plumbed through as `ctx.tol_for('.parquet')` — so adding a new format doesn't require signature changes.

### XOR relaxation
The `want_data` XOR `want_metadata` rule still fires when both are `MEDSDataset` + `pl.DataFrame` (the original ambiguity). It's relaxed when either is a `Path` — extraction stages legitimately describe both data and metadata file trees simultaneously.

## What this doesn't do

- No changes to `example_class` — stages that need fully custom rendering (`JsonOutputStageExample`-style) keep their escape hatch.
- No changes to `render_content` — #389 handled the `want_metadata: Path` rendering bug on its own.
- No downstream migrations — those land as PRs against the MTD and MEDS-extract repos once this merges.

## Test plan

- [x] 18 new tests in `tests/test_filespec_stageexample.py`:
  - Path fallback in `from_dir` + existing MEDSDataset parsing unchanged
  - `check_outputs` dispatch for Path spec (match / mismatch / missing-file / unknown-suffix)
  - Policy fields (`tolerate_unexpected`, `skip_dirs`, `skip_files`)
  - Class-level comparator registration
  - Per-instance `suffix_comparators` wins over class default
  - `_compare_parquet` tolerance bridging
  - MEDSDataset legacy branch un-regressed
- [x] Full test suite: **177 passed**, 2 pre-existing parallel-only failures unrelated.
- [x] All existing doctests still pass.

Refs #387